### PR TITLE
CI: fix missing sudo in apt install

### DIFF
--- a/.github/workflows/scripts/cuda-install.sh
+++ b/.github/workflows/scripts/cuda-install.sh
@@ -5,15 +5,15 @@ cuda_version=$(echo $1 | tr "." "-")
 # Removes '-' and '.' ex: ubuntu-20.04 -> ubuntu2004
 OS=$(echo $2 | tr -d ".\-")
 
-apt -qq update
-apt install -y wget gnupg2
+sudo apt -qq update
+sudo apt install -y wget gnupg2
 
 # Installs CUDA
 wget -nv https://developer.download.nvidia.com/compute/cuda/repos/${OS}/x86_64/cuda-keyring_1.1-1_all.deb
 dpkg -i cuda-keyring_1.1-1_all.deb
 rm cuda-keyring_1.1-1_all.deb
-apt --no-install-recommends -y install cuda-nvcc-${cuda_version} cuda-libraries-dev-${cuda_version}
-apt clean
+sudo apt --no-install-recommends -y install cuda-nvcc-${cuda_version} cuda-libraries-dev-${cuda_version}
+sudo apt clean
 
 # Test nvcc
 PATH=/usr/local/cuda-$1/bin:${PATH}


### PR DESCRIPTION
## Description
Missing `sudo` in `apt update` and `apt install` causes installation faiilure.
```bash
+ apt -qq update

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
E: Unable to lock directory /var/lib/apt/lists/
```

https://github.com/EfficientMoE/MoE-Infinity/actions/runs/13684170872/job/38263491358#step:8:18

## Motivation


## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/EfficientMoE/MoE-Infinity/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
