### PR TITLE
CI: revert os matrix in CI

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -26,10 +26,12 @@ jobs:
 
   wheel:
     name: Build Wheel
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
+        os: ['ubuntu-20.04']
         python-version: ['3.8', '3.9', '3.10', '3.11']
         cuda-version: ['11.8', '12.1']
 


### PR DESCRIPTION
## Description
Use os matrix in CI to let cuda installation script use the environment variable.

## Motivation

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] I have read the [CONTRIBUTION](https://github.com/EfficientMoE/MoE-Infinity/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
