### PR TITLE
fix(kernel): fused_decode_attention raises TypeError whenever MOE_DISABLE_FUSED_KERNELS=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to MoE-Infinity will be documented in this file.
 - GPT-OSS resident-load path now materializes MXFP4 blocks, scales, router, biases, and attention sinks instead of leaving placeholder tensors in place.
 - GLM FP8 store and reload parity now stays stable across fresh stores and reloads.
 - PyPI publishing for both stable (`publish.yml`) and nightly (`publish-test.yml`): stable releases now take their version from the pushed git tag instead of always publishing `0.0.1`, and nightly sdists carry their version in `PKG-INFO` so `pip install --pre moe-infinity` no longer fails with a `MetadataInconsistent` version mismatch on rebuild.
+- `MOE_DISABLE_FUSED_KERNELS=1` no longer raises `TypeError` on decode: `fused_decode_attention` now has its own eager fallback instead of delegating to `paged_attention_fwd`, which takes a different KV cache layout and a required `num_kv_heads` argument.
 
 ### Known Limitations
 

--- a/moe_infinity/kernel/__init__.py
+++ b/moe_infinity/kernel/__init__.py
@@ -68,6 +68,58 @@ def fused_ffn(
     return _impl(x, gate_weight, up_weight, down_weight)
 
 
+def _decode_attention_eager(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Eager equivalent of the fused decode kernel, in the same paged layout.
+
+    query is ``[batch, 1, num_heads, head_dim]`` and the caches are
+    ``[num_blocks, block_size, num_kv_heads, head_dim]``, which is the layout
+    ``fused_decode_attn`` uses -- not the vLLM layout ``paged_attention_fwd``
+    expects.
+    """
+    batch, _, num_heads, _ = query.shape
+    _, block_size, num_kv_heads, _ = key_cache.shape
+    if num_heads % num_kv_heads != 0:
+        raise ValueError("num_heads must be divisible by num_kv_heads")
+    query_group_size = num_heads // num_kv_heads
+
+    out = torch.zeros(
+        query.shape[0],
+        num_heads,
+        query.shape[-1],
+        dtype=query.dtype,
+        device=query.device,
+    )
+    for seq_idx in range(batch):
+        seq_len = int(seq_lens[seq_idx].item())
+        if seq_len <= 0:
+            continue
+
+        offsets = torch.arange(seq_len, device=query.device)
+        physical_block = block_tables[seq_idx][offsets // block_size].long()
+        token_in_block = offsets % block_size
+
+        # [seq_len, num_kv_heads, head_dim] -> [seq_len, num_heads, head_dim]
+        k = key_cache[physical_block, token_in_block].float()
+        v = value_cache[physical_block, token_in_block].float()
+        if query_group_size > 1:
+            k = k.repeat_interleave(query_group_size, dim=1)
+            v = v.repeat_interleave(query_group_size, dim=1)
+
+        q = query[seq_idx, 0].float()
+        logits = (k * q.unsqueeze(0)).sum(dim=-1) * scale
+        probs = torch.softmax(logits, dim=0)
+        out[seq_idx] = (probs.unsqueeze(-1) * v).sum(dim=0).to(query.dtype)
+
+    return out
+
+
 def fused_decode_attention(
     query: torch.Tensor,
     key_cache: torch.Tensor,
@@ -76,9 +128,9 @@ def fused_decode_attention(
     seq_lens: torch.Tensor,
     scale: float,
 ) -> torch.Tensor:
-    """Fused decode attention with paged KV. Falls back to FlashInfer/SDPA if disabled."""
+    """Fused decode attention with paged KV. Falls back to eager if disabled."""
     if _FUSED_KERNELS_DISABLED:
-        return paged_attention_fwd(
+        return _decode_attention_eager(
             query, key_cache, value_cache, block_tables, seq_lens, scale
         )
     from .fused_decode_attn import fused_decode_attention as _impl

--- a/tests/python/ops/test_fused_decode_attn.py
+++ b/tests/python/ops/test_fused_decode_attn.py
@@ -172,3 +172,64 @@ def test_fused_decode_attention_matches_reference(
         atol=BF16_ATOL,
         rtol=BF16_RTOL,
     )
+
+
+@pytest.mark.parametrize("num_kv_heads", [8, 32])
+def test_fused_decode_attention_falls_back_to_eager_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    num_kv_heads: int,
+) -> None:
+    """``MOE_DISABLE_FUSED_KERNELS=1`` must still compute decode attention.
+
+    The fallback runs without CUDA or Triton, so this covers the CPU-only
+    path that the parametrized kernel test above cannot reach.
+    """
+    from moe_infinity import kernel
+
+    monkeypatch.setattr(kernel, "_FUSED_KERNELS_DISABLED", True)
+
+    batch, seq_len, num_heads, head_dim, block_size = 2, 40, 32, 128, 16
+    device = torch.device("cpu")
+    query = torch.randn(
+        batch,
+        1,
+        num_heads,
+        head_dim,
+        device=device,
+        dtype=torch.float32,
+    ).to(torch.bfloat16)
+    key_cache, value_cache, block_tables, seq_lens = _make_paged_kv(
+        batch=batch,
+        seq_len=seq_len,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        device=device,
+    )
+    scale = 1.0 / math.sqrt(float(head_dim))
+
+    output = kernel.fused_decode_attention(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+    )
+    reference = _reference_decode_attention(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+    )
+
+    assert output.shape == (batch, num_heads, head_dim)
+    assert output.dtype == torch.bfloat16
+    torch.testing.assert_close(
+        output.float(),
+        reference.float(),
+        atol=BF16_ATOL,
+        rtol=BF16_RTOL,
+    )


### PR DESCRIPTION
## Description

`fused_decode_attention` in `moe_infinity/kernel/__init__.py` raises on every call when fused kernels are disabled:

```
TypeError: paged_attention_fwd() missing 1 required positional argument: 'num_kv_heads'
```

The `_FUSED_KERNELS_DISABLED` branch forwards six positional arguments to `paged_attention_fwd`, but that function's signature is `(query, key_cache, value_cache, block_tables, seq_lens, scale, num_kv_heads, block_size=16, max_seq_len=None)` — `num_kv_heads` has no default. The only other caller, `runtime/attention_backend.py:431`, does pass it (`num_kv_heads=self.spec.num_kv_heads`).

Delegating there could not work even with the argument added, because the two functions take different shapes:

| | `fused_decode_attention` | `paged_attention_fwd` |
| --- | --- | --- |
| query | `[batch, 1, num_heads, head_dim]` (4-D) | `[num_seqs, num_heads, head_dim]` (3-D, `ValueError` otherwise) |
| KV cache | `[num_blocks, block_size, num_kv_heads, head_dim]` | vLLM layout, unpacked as `nkv, hd_x, _, x` in `_paged_attention_sdpa_fallback` |

So this fix gives `fused_decode_attention` its own eager fallback in its own layout, which is what its two siblings in the same file already do — `fused_qkv_proj` falls back to three matmuls and `fused_ffn` falls back to eager SiLU. This one was the odd one out.

## Motivation

`MOE_DISABLE_FUSED_KERNELS=1` is the documented escape hatch for disabling fused kernels. Today it makes decode unusable, so the flag cannot be used to isolate a fused-kernel problem — the case it exists for. The fallback also needs neither CUDA nor Triton, which the fused path both require.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Documentation impact

- [x] CHANGELOG `Unreleased` updated.

No other docs change: this restores the already-documented behaviour of an existing env var rather than adding or altering a user-facing feature.

## Performance / support evidence

- [x] Not applicable — the fused/Triton path is untouched. The only changed code runs when `MOE_DISABLE_FUSED_KERNELS=1`, where the previous behaviour was an unconditional `TypeError`, so there is no prior performance baseline to regress.

## Verification

Reproduced and verified by running the real repo files (no hand-copied source), CPU/CUDA, torch 2.5.1+cu121:

**Before** — `MOE_DISABLE_FUSED_KERNELS=1`, shapes exactly as `fused_decode_attention`'s own docstring specifies:

```
RAISED TypeError: paged_attention_fwd() missing 1 required positional argument: 'num_kv_heads'
```

**After** — output compared against an independent transcription of `_fused_decode_attention_kernel`'s own math (online softmax, `kv_head_idx = head_idx // QUERY_GROUP_SIZE`, zero-fill on `seq_len <= 0`):

```
B=2 H=4  KV=2 D=64:  shape=(2, 4, 64)  dtype=torch.bfloat16 max|diff|=0 -> PASS
B=3 H=8  KV=8 D=128: shape=(3, 8, 128) dtype=torch.bfloat16 max|diff|=0 -> PASS
B=1 H=8  KV=2 D=64:  shape=(1, 8, 64)  dtype=torch.bfloat16 max|diff|=0 -> PASS
seq_len=0 -> all zeros: PASS
```

Both GQA (`num_heads > num_kv_heads`) and MHA are covered, since the head-group mapping is where an eager rewrite is easiest to get wrong.

The new test reuses the file's existing `_make_paged_kv` and `_reference_decode_attention` helpers, so the fallback is checked against the same reference the Triton kernel is. It fails on `main` with the `TypeError` above and passes with this change:

```
$ python -m pytest tests/python/ops/test_fused_decode_attn.py -q
2 passed, 24 skipped     # 24 skipped = Triton not installed on this box
```

`ruff==0.6.9` (the version pinned in `.pre-commit-config.yaml`) reports `2 files already formatted` and `All checks passed!`.

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/EfficientMoE/MoE-Infinity/blob/main/CONTRIBUTING.md) guide.
- [x] I have updated the tests (if applicable).
- [x] I have filled out the documentation impact section above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
