### PR TITLE
fix: single-owner kTopologyHandle guard + adaptive-memory benchmark hardening

### DIFF
--- a/benchmarks/serving/memory.py
+++ b/benchmarks/serving/memory.py
@@ -89,6 +89,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--seed", type=int, default=7)
     parser.add_argument("--trace-output", default=None)
+    parser.add_argument("--_arm", choices=("fixed", "adaptive"), default=None)
     return parser.parse_args()
 
 
@@ -171,7 +172,8 @@ def load_model_and_tokenizer(
     config = {
         "offload_path": offload_dir,
         "device_memory_ratio": arm.device_memory_ratio,
-        "kv_cache_ratio": arm.kv_cache_ratio,
+        "kv_cache_memory_ratio": arm.kv_cache_ratio,
+        "enable_kv_cache_offload": arm.kv_cache_ratio > 0,
         "adaptive_memory_enabled": arm.adaptive_memory_enabled,
     }
     model = moe_class(model_name, config)
@@ -423,7 +425,7 @@ def run_memory_benchmark(
     )
 
     prompt_token_ids = build_prompt_token_ids(tokenizer, prompt_length)
-    sampling_params = SamplingParams(max_tokens=max_new_tokens)
+    sampling_params = SamplingParams(max_tokens=max_new_tokens, temperature=0.0)
     for index in range(batch_size):
         cb_engine.add_request(
             request_id=f"memory-req-{index}",
@@ -500,8 +502,61 @@ def run_arm(arm: ArmConfig, args: argparse.Namespace) -> dict[str, Any]:
 def compare_arms(
     arms: list[ArmConfig], args: argparse.Namespace
 ) -> dict[str, Any]:
+    import os
+    import subprocess
+    import sys
+
     ordered = list(reversed(arms)) if int(args.seed) % 2 == 0 else list(arms)
-    results = [run_arm(arm, args) for arm in ordered]
+    runner = [sys.executable]
+    wt_root = os.environ.get("MOE_WT_ROOT")
+    if wt_root:
+        runner.append(
+            os.path.join(os.path.dirname(wt_root.rstrip("/")), "_runwt.py")
+        )
+    results: list[dict[str, Any]] = []
+    for arm in ordered:
+        arm_out = f"{args.output_json}.{arm.arm}.json"
+        arm_offload = os.path.join(args.offload_dir, arm.arm)
+        os.makedirs(arm_offload, exist_ok=True)
+        cmd = runner + [
+            os.path.abspath(__file__),
+            "--model",
+            args.model,
+            "--offload-dir",
+            arm_offload,
+            "--batch-size",
+            str(args.batch_size),
+            "--prompt-length",
+            str(args.prompt_length),
+            "--max-new-tokens",
+            str(args.max_new_tokens),
+            "--device-memory-ratio",
+            str(args.device_memory_ratio),
+            "--kv-cache-ratio",
+            str(args.kv_cache_ratio),
+            "--warmup-runs",
+            str(args.warmup_runs),
+            "--repetitions",
+            str(args.repetitions),
+            "--seed",
+            str(args.seed),
+            "--output-json",
+            arm_out,
+            "--_arm",
+            arm.arm,
+        ]
+        proc = subprocess.run(cmd)
+        if proc.returncode != 0:
+            results.append(
+                {
+                    "arm": arm.arm,
+                    "status": "BLOCKED",
+                    "reason": f"arm subprocess exit {proc.returncode}",
+                }
+            )
+            continue
+        with open(arm_out, "r", encoding="utf-8") as handle:
+            results.append(json.load(handle)["result"])
     return {
         "seed": int(args.seed),
         "arm_order": [arm.arm for arm in ordered],
@@ -576,6 +631,20 @@ def main() -> int:
             "batch_size": args.batch_size,
         }
         write_json(output_path, payload)
+        return 0
+
+    if args._arm is not None:
+        arm = ArmConfig(
+            args._arm,
+            args.device_memory_ratio,
+            args.kv_cache_ratio,
+            args._arm == "adaptive",
+        )
+        result = run_arm(arm, args)
+        write_json(
+            output_path,
+            {"arm": args._arm, "result": result, "environment": env},
+        )
         return 0
 
     if args.adaptive_memory:

--- a/core/parallel/expert_dispatcher.cpp
+++ b/core/parallel/expert_dispatcher.cpp
@@ -130,8 +130,9 @@ ExpertDispatcher::ExpertDispatcher(int num_experts, int num_layers, int dtype,
     threads_.emplace_back(new base::Thread(thread_func, thread_name));
     threads_.back()->start();
 
-    auto cache_limit =
-        kTopologyHandle->GetSparseCacheLimit(torch::Device(torch::kCUDA, i));
+    auto cache_limit = kTopologyHandle ? kTopologyHandle->GetSparseCacheLimit(
+                                             torch::Device(torch::kCUDA, i))
+                                       : static_cast<std::int64_t>(-1);
     cache_sizes_.push_back(cache_limit);
   }
 

--- a/core/prefetch/archer_prefetch_handle.cpp
+++ b/core/prefetch/archer_prefetch_handle.cpp
@@ -6,6 +6,7 @@
 #include "archer_prefetch_handle.h"
 
 #include <cstdlib>
+#include <stdexcept>
 #include <cuda_runtime_api.h>
 #include <torch/extension.h>
 #include "aio/archer_tensor_handle.h"
@@ -20,6 +21,11 @@
 ArcherPrefetchHandle::ArcherPrefetchHandle(const std::string& prefix,
                                            const double device_memory_ratio)
     : prefix_(prefix), last_layer_id_(0), has_cleaned_up_resources_(false) {
+  if (kTopologyHandle != nullptr) {
+    throw std::runtime_error(
+        "MoE-Infinity supports one model per process; a model is already "
+        "loaded. Construct additional models in separate processes.");
+  }
   // InitLogger();
   int num_io_threads = 0;
   const char* io_threads_env = std::getenv("MOE_IO_THREADS");

--- a/tests/cpp/unit/prefetch/CMakeLists.txt
+++ b/tests/cpp/unit/prefetch/CMakeLists.txt
@@ -25,3 +25,22 @@ target_include_directories(test_sparse_cache_resize PRIVATE ${CMAKE_SOURCE_DIR}/
 find_package(Python3 COMPONENTS Development REQUIRED)
 target_link_libraries(test_sparse_cache_resize PRIVATE Python3::Python)
 add_test(NAME sparse_cache_resize COMMAND test_sparse_cache_resize)
+
+add_executable(test_topology_lifecycle
+  test_topology_lifecycle.cpp
+  ${CMAKE_SOURCE_DIR}/extensions/kernel/v4_fp4/fp8_dequant.cu
+  ${CMAKE_SOURCE_DIR}/extensions/kernel/v4_fp4/mxfp4_dequant.cu
+)
+set_target_properties(test_topology_lifecycle PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+)
+foreach(_gtest_tgt GTest::gtest GTest::gtest_main)
+  if(TARGET ${_gtest_tgt})
+    set_target_properties(${_gtest_tgt} PROPERTIES INTERFACE_COMPILE_FEATURES "")
+  endif()
+endforeach()
+target_link_libraries(test_topology_lifecycle PRIVATE archer_core GTest::gtest_main)
+target_include_directories(test_topology_lifecycle PRIVATE ${CMAKE_SOURCE_DIR}/core)
+target_link_libraries(test_topology_lifecycle PRIVATE Python3::Python)
+add_test(NAME topology_lifecycle COMMAND test_topology_lifecycle)

--- a/tests/cpp/unit/prefetch/test_topology_lifecycle.cpp
+++ b/tests/cpp/unit/prefetch/test_topology_lifecycle.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+#include "model/model_topology.h"
+#include "prefetch/archer_prefetch_handle.h"
+
+namespace {
+
+std::string MakePrefix(const char* name) {
+  std::string prefix = std::string("/tmp/moe_topo_lifecycle_") + name + "/";
+  std::filesystem::create_directories(prefix);
+  return prefix;
+}
+
+TEST(TopologyLifecycle, SecondConstructionThrowsInsteadOfCorrupting) {
+  ArcherPrefetchHandle first(MakePrefix("a"), 0.5);
+  ASSERT_NE(kTopologyHandle, nullptr);
+  EXPECT_THROW(
+      { ArcherPrefetchHandle second(MakePrefix("a2"), 0.5); },
+      std::runtime_error);
+  EXPECT_NE(kTopologyHandle, nullptr);
+}
+
+TEST(TopologyLifecycle, ConstructionAfterDestroyIsAllowed) {
+  { ArcherPrefetchHandle first(MakePrefix("b"), 0.5); }
+  EXPECT_EQ(kTopologyHandle, nullptr);
+  EXPECT_NO_THROW({ ArcherPrefetchHandle again(MakePrefix("b2"), 0.5); });
+}
+
+}  // namespace

--- a/tests/python/unit/test_multi_model_guard.py
+++ b/tests/python/unit/test_multi_model_guard.py
@@ -1,0 +1,25 @@
+import os
+
+import pytest
+
+from moe_infinity import _store
+
+
+def _prefix(name: str) -> str:
+    path = f"/tmp/moe_multimodel_{name}/"
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def test_second_handle_raises_instead_of_corrupting():
+    first = _store.prefetch_handle(_prefix("a"), 0.5)
+    with pytest.raises(RuntimeError):
+        _store.prefetch_handle(_prefix("b"), 0.5)
+    del first
+
+
+def test_handle_construction_after_destroy_is_allowed():
+    first = _store.prefetch_handle(_prefix("c"), 0.5)
+    del first
+    second = _store.prefetch_handle(_prefix("d"), 0.5)
+    del second


### PR DESCRIPTION
Productization fixes for the adaptive-expert-kv-memory line (see docs/superpowers/reports/2026-08-30-productization-verdicts.md).

- **archer_prefetch_handle**: throw if the global `kTopologyHandle` is already set — converts the silent 'load 2 models in one process' corruption (root cause of the #177/#181 segfaults) into an immediate, clear error.
- **expert_dispatcher**: null-guard `GetSparseCacheLimit`.
- **memory.py benchmark**: run each arm in its own subprocess + offload dir; greedy sampling (temperature=0.0) to avoid the multinomial inf/nan assert.
- **tests**: multi-model guard pytest + native topology-lifecycle GTest.

Verified: `test_multi_model_guard.py` (2 passed). Excludes the local `kMaxTokens` benchmark tweak.