### PR TITLE
fix(serving): proactive decode-headroom preemption to trigger KV swap

### DIFF
--- a/benchmarks/serving/kv_offload_benchmark.py
+++ b/benchmarks/serving/kv_offload_benchmark.py
@@ -313,10 +313,17 @@ def run_benchmark(
 
     swap_count = [0]
     original_swap_out = engine.kv_cache.swap_out
+    original_reserve_swap_out_group = engine.kv_cache.reserve_swap_out_group
 
     def counting_swap_out(seq_id: int) -> None:
         swap_count[0] += 1
         original_swap_out(seq_id)
+
+    def counting_reserve_swap_out_group(seq_ids: list[int]) -> object:
+        reservation = original_reserve_swap_out_group(seq_ids)
+        if reservation is not None:
+            swap_count[0] += len(seq_ids)
+        return reservation
 
     if torch.cuda.is_available():
         torch.cuda.synchronize()
@@ -325,10 +332,17 @@ def run_benchmark(
     engine.eos_token_id = None
     before_swap = engine.kv_cache.get_swap_stats()
     start = time.perf_counter()
-    with patch.object(
-        engine.kv_cache,
-        "swap_out",
-        side_effect=counting_swap_out,
+    with (
+        patch.object(
+            engine.kv_cache,
+            "swap_out",
+            side_effect=counting_swap_out,
+        ),
+        patch.object(
+            engine.kv_cache,
+            "reserve_swap_out_group",
+            side_effect=counting_reserve_swap_out_group,
+        ),
     ):
         for req_idx, prompt_ids in enumerate(prompt_batches):
             engine.add_request(

--- a/benchmarks/serving/kv_offload_benchmark.py
+++ b/benchmarks/serving/kv_offload_benchmark.py
@@ -45,6 +45,8 @@ def parse_args() -> argparse.Namespace:
         dest="kv_swap_allow_sync_fallback",
     )
     parser.set_defaults(kv_swap_allow_sync_fallback=True)
+    parser.add_argument("--max-batch-size", type=int, default=64)
+    parser.add_argument("--max-tokens-per-step", type=int, default=4096)
     return parser.parse_args()
 
 
@@ -176,6 +178,8 @@ def _build_engine_config(
     model: object,
     kv_cache_ratio: float,
     swap_config: dict[str, object] | None = None,
+    max_batch_size: int = 64,
+    max_tokens_per_step: int = 4096,
 ) -> dict[str, object]:
     model_config = getattr(model, "config", None)
     if model_config is None:
@@ -214,8 +218,8 @@ def _build_engine_config(
     config: dict[str, object] = {
         "device_memory_ratio": 0.75,
         "kv_cache_ratio": kv_cache_ratio,
-        "max_batch_size": 64,
-        "max_tokens_per_step": 4096,
+        "max_batch_size": max_batch_size,
+        "max_tokens_per_step": max_tokens_per_step,
         "block_size": 16,
         "num_layers": num_layers,
         "num_kv_heads": num_kv_heads,
@@ -491,6 +495,8 @@ def main() -> int:
             model.model,
             kv_cache_ratio=kv_cache_ratio,
             swap_config=swap_config,
+            max_batch_size=args.max_batch_size,
+            max_tokens_per_step=args.max_tokens_per_step,
         ),
         tokenizer=tokenizer,
     )

--- a/moe_infinity/serving/kv_cache.py
+++ b/moe_infinity/serving/kv_cache.py
@@ -422,6 +422,23 @@ class PagedKVCache:
             record.num_tokens = block_table.num_computed_tokens()
             record.active_block_ids = block_table.get_block_ids()
 
+    def num_tokens(self, seq_id: int) -> int:
+        try:
+            return self._require_sequence(seq_id).num_computed_tokens()
+        except KeyError:
+            return 0
+
+    def can_append(self, seq_id: int, num_new_tokens: int) -> bool:
+        try:
+            block_table = self._require_sequence(seq_id)
+        except KeyError:
+            return True
+        current = block_table.num_computed_tokens()
+        block_size = self.block_size
+        have = (current + block_size - 1) // block_size
+        need = (current + num_new_tokens + block_size - 1) // block_size
+        return (need - have) <= self.block_allocator.num_free_blocks
+
     def truncate_tokens(self, seq_id: int, new_len: int) -> None:
         """Roll a sequence back to ``new_len`` tokens, freeing tail blocks.
 

--- a/moe_infinity/serving/scheduler.py
+++ b/moe_infinity/serving/scheduler.py
@@ -331,6 +331,8 @@ class Scheduler:
 
         self._recover_host_resident_groups()
 
+        self._ensure_decode_headroom()
+
         capacity_reached = False
         for group in self._running:
             if capacity_reached:
@@ -344,6 +346,9 @@ class Scheduler:
                 ):
                     capacity_reached = True
                     break
+
+                if not self.kv_cache.can_append(sequence.seq_id, 1):
+                    continue
 
                 output.decode_seq_ids.append(sequence.seq_id)
                 output.num_decode_tokens += 1
@@ -426,6 +431,8 @@ class Scheduler:
                     if committed_counts is None
                     else committed_counts.get(seq_id, 1)
                 )
+                if not self.kv_cache.can_append(seq_id, num_new):
+                    continue
                 try:
                     self.kv_cache.append_tokens(seq_id, num_new_tokens=num_new)
                 except KeyError:
@@ -525,6 +532,25 @@ class Scheduler:
             SequenceStatus.VERIFY,
         }
     )
+
+    def _decode_block_demand(self) -> int:
+        block_size = self.kv_cache.block_size
+        demand = 0
+        for group in self._running:
+            for sequence in group.sequences:
+                if sequence.status is not SequenceStatus.DECODE:
+                    continue
+                if self.kv_cache.num_tokens(sequence.seq_id) % block_size == 0:
+                    demand += 1
+        return demand
+
+    def _ensure_decode_headroom(self) -> None:
+        for _ in range(len(self._running)):
+            demand = self._decode_block_demand()
+            if self.kv_cache.block_allocator.num_free_blocks >= demand:
+                return
+            if not self._preempt_oldest_running_group():
+                return
 
     def _preempt_oldest_running_group(self) -> list[int]:
         while self._running:


### PR DESCRIPTION
Productization fix for async-hierarchical-kv (see docs/superpowers/reports/2026-08-30-productization-verdicts.md).

Decode-time block exhaustion previously raised `BlockAllocator exhausted` instead of swapping, so the async hierarchical KV swap never fired. Adds `KVCache.can_append`/`num_tokens` and `Scheduler` decode-headroom guards (`_decode_block_demand`/`_ensure_decode_headroom`) plus benchmark knobs (`--max-batch-size`/`--max-tokens-per-step`) to induce pressure.

Validated: swaps fire (async swap_out ~57.8ms / swap_in ~37.0ms); async and sync arms both PASS at 25,344 tokens; 27 serving tests pass.