### PR TITLE
fix(serving): serialize SSE generator + FlashInfer plan dtype (bf16)

### DIFF
--- a/moe_infinity/entrypoints/openai/api_server_v2.py
+++ b/moe_infinity/entrypoints/openai/api_server_v2.py
@@ -927,17 +927,25 @@ async def _completion_event_generator(
     raw_request: Request,
 ) -> Any:
     runtime_engine, _ = _ensure_runtime_ready()
+    pending: Optional["asyncio.Future[Optional[str]]"] = None
     while True:
         if await raw_request.is_disconnected():
             runtime_engine.abort_request(request_id)
+            if pending is not None:
+                _ = pending.cancel()
             return
+        if pending is None:
+            pending = asyncio.ensure_future(
+                asyncio.to_thread(_next_stream_event, stream)
+            )
         try:
             event = await asyncio.wait_for(
-                asyncio.to_thread(_next_stream_event, stream),
+                asyncio.shield(pending),
                 timeout=0.1,
             )
         except asyncio.TimeoutError:
             continue
+        pending = None
 
         if event is None:
             return
@@ -971,17 +979,25 @@ async def _chat_event_generator(
     *, request_id: str, stream: Any, raw_request: Request
 ) -> Any:
     runtime_engine, _ = _ensure_runtime_ready()
+    pending: Optional["asyncio.Future[Optional[str]]"] = None
     while True:
         if await raw_request.is_disconnected():
             runtime_engine.abort_request(request_id)
+            if pending is not None:
+                _ = pending.cancel()
             return
+        if pending is None:
+            pending = asyncio.ensure_future(
+                asyncio.to_thread(_next_stream_event, stream)
+            )
         try:
             event = await asyncio.wait_for(
-                asyncio.to_thread(_next_stream_event, stream),
+                asyncio.shield(pending),
                 timeout=0.1,
             )
         except asyncio.TimeoutError:
             continue
+        pending = None
 
         if event is None:
             return
@@ -991,6 +1007,7 @@ async def _chat_event_generator(
 
 
 async def _engine_loop() -> None:
+    _logger.info("engine loop started")
     while (
         _engine_shutdown_event is not None
         and not _engine_shutdown_event.is_set()
@@ -999,18 +1016,23 @@ async def _engine_loop() -> None:
             await asyncio.sleep(0.01)
             continue
 
-        if engine.has_pending_requests():
-            if _decode_watchdog is not None:
-                _decode_watchdog.activate()
-            _ = engine.step()
-            if _decode_watchdog is not None:
-                _decode_watchdog.feed()
-            await asyncio.sleep(0)
-            continue
+        try:
+            if engine.has_pending_requests():
+                if _decode_watchdog is not None:
+                    _decode_watchdog.activate()
+                _ = engine.step()
+                if _decode_watchdog is not None:
+                    _decode_watchdog.feed()
+                await asyncio.sleep(0)
+                continue
 
-        if _decode_watchdog is not None:
-            _decode_watchdog.deactivate()
-        await asyncio.sleep(0.005)
+            if _decode_watchdog is not None:
+                _decode_watchdog.deactivate()
+            await asyncio.sleep(0.005)
+        except Exception as exc:
+            _logger.exception("engine loop step failed")
+            _health_state.set_unhealthy(f"engine loop failed: {exc}")
+            return
 
 
 def _ensure_engine_loop_running() -> None:

--- a/moe_infinity/runtime/attention_backend.py
+++ b/moe_infinity/runtime/attention_backend.py
@@ -752,6 +752,9 @@ class PagedAttentionBackend:
                 self.spec.num_kv_heads,
                 self.spec.head_dim,
                 self.spec.block_size,
+                causal=True,
+                q_data_type=self.spec.dtype,
+                kv_data_type=self.spec.dtype,
             )
         except TypeError:
             self._fi_prefill.plan(
@@ -786,6 +789,9 @@ class PagedAttentionBackend:
                 self.spec.num_kv_heads,
                 self.spec.head_dim,
                 self.spec.block_size,
+                pos_encoding_mode="NONE",
+                q_data_type=query_dtype,
+                kv_data_type=query_dtype,
             )
         except TypeError:
             self._fi_decode.plan(

--- a/moe_infinity/serving/kv_cache.py
+++ b/moe_infinity/serving/kv_cache.py
@@ -427,7 +427,17 @@ class PagedKVCache:
             raise ValueError("paged KV head-count mismatch")
         if store.head_dim != self.head_dim:
             raise ValueError("paged KV head-dimension mismatch")
-        if store.dtype != self.dtype or store.device != self.device:
+
+        def _dev_key(device: torch.device) -> tuple[str, int]:
+            if device.index is not None:
+                return (device.type, device.index)
+            if device.type == "cuda":
+                return (device.type, torch.cuda.current_device())
+            return (device.type, -1)
+
+        if store.dtype != self.dtype or _dev_key(store.device) != _dev_key(
+            self.device
+        ):
             raise ValueError("paged KV dtype/device mismatch")
         self._block_store = store
 


### PR DESCRIPTION
General serving-infra fixes surfaced while productizing chunked-prefill (see docs/superpowers/reports/2026-08-30-productization-verdicts.md). These are independent of the chunked feature itself.

- **api_server_v2**: persist a single **shielded** `next(stream)` future across the 0.1s disconnect-poll so concurrent `next()` no longer raises `ValueError: generator already executing` (this hung all streamed requests). Also log + set UNHEALTHY when the engine loop dies instead of hanging silently.
- **attention_backend**: pass `q_data_type`/`kv_data_type` (bf16) to the FlashInfer prefill+decode plans — the float16 default caused `dtype of q bfloat16 does not match q_data_type float16`, which silently killed the async engine loop on Qwen3.
- **kv_cache.set_block_store**: normalize cuda device index in the geometry check.

Verified: whole-prefill now generates ('The capital of France is' -> ' Paris...'). NOTE: chunked-prefill itself remains blocked by a separate KV block-budget sizing issue (logical 10940 > physical 9725) documented in the report — not addressed here.