### PR TITLE
fix(serving): fail loud when a served model has no paged-attention shim

### DIFF
--- a/moe_infinity/serving/model_runner.py
+++ b/moe_infinity/serving/model_runner.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from collections.abc import Iterable, Mapping
 from typing import Any, Optional, Protocol, runtime_checkable
 
@@ -12,6 +14,8 @@ from moe_infinity.runtime.attention_types import (
 )
 
 from .batch import BatchMetadata
+
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -40,6 +44,7 @@ class ModelRunner:
         self.engine = engine
         self.device = self._resolve_device(device)
         self.seq_id_list = []
+        self._warned_no_paged_shim = False
 
     def prepare_inputs(self, batch: BatchMetadata) -> dict[str, torch.Tensor]:
         num_seqs = len(batch.seq_ids)
@@ -122,6 +127,22 @@ class ModelRunner:
         use_paged_context = bool(
             paged_attention_classes and backend is not None
         )
+
+        # Backend present but no shim matched => paged cache is never wired into
+        # attention and decode silently degenerates; surface it (see issue #191).
+        if backend is not None and not paged_attention_classes:
+            _msg = (
+                "MoE-Infinity serving: no paged-attention shim matched the "
+                f"served model ({type(self.model).__name__}); the paged KV "
+                "cache is NOT wired into its attention, so multi-token decode "
+                "output will be INCORRECT. Implement a *PagedAttention shim for "
+                "this model (reference: moe_infinity/models/qwen3_paged_attention.py)."
+            )
+            if os.environ.get("MOE_STRICT_PAGED_ATTENTION", "0") == "1":
+                raise RuntimeError(_msg)
+            if not self._warned_no_paged_shim:
+                logger.warning(_msg)
+                self._warned_no_paged_shim = True
 
         with torch.no_grad():
             if not use_paged_context:


### PR DESCRIPTION
## What

Interim safety guard for the silent decode-degeneration bug in #191.

When the continuous-batching runner has a paged KV **backend** configured but **no** paged-attention shim matches the served model, the paged cache is never wired into attention and multi-token decode silently produces garbage (correct first token, then collapse). Today only `Qwen3PagedAttention` is implemented; `DeepseekV2/V3PagedAttention` exist only in tests, so DeepSeek-V2/V3 hit this path.

This PR makes that failure **visible** instead of silent, in `moe_infinity/serving/model_runner.py`:

- **Default:** log a clear one-time warning naming the served model and explaining decode output will be incorrect.
- **Opt-in strict:** raise `RuntimeError` when `MOE_STRICT_PAGED_ATTENTION=1`, so operators can choose "error out" over "serve garbage".

## Why it's safe (no regression)

- Fires **only** when `backend is not None and not paged_attention_classes` — i.e., exactly the broken case.
- Models **with** a shim (e.g. Qwen3-MoE) have non-empty `paged_attention_classes`, so the guard is skipped entirely.
- Default behavior is warn-only (once per runner); no functional change to any currently-working model. The hard failure is strictly opt-in.

## Scope

Interim guard only. The real fix — implementing production `DeepseekV2/V3PagedAttention` MLA shims — is tracked in #191.

## Verification

- `lsp_diagnostics` clean on the changed file.
- Root cause reproduced live (DeepSeek-V2-Lite-Chat serving: correct first token, then repeated-digit collapse; identical with `MOE_DISABLE_FUSED_KERNELS` on/off).

Refs #191