### PR TITLE
fix(#178): complete chunked prefill — KV budget cap, FlashInfer workspace, ragged attention

### DIFF
--- a/moe_infinity/entrypoints/openai/api_server_v2.py
+++ b/moe_infinity/entrypoints/openai/api_server_v2.py
@@ -927,17 +927,25 @@ async def _completion_event_generator(
     raw_request: Request,
 ) -> Any:
     runtime_engine, _ = _ensure_runtime_ready()
+    pending: Optional["asyncio.Future[Optional[str]]"] = None
     while True:
         if await raw_request.is_disconnected():
             runtime_engine.abort_request(request_id)
+            if pending is not None:
+                _ = pending.cancel()
             return
+        if pending is None:
+            pending = asyncio.ensure_future(
+                asyncio.to_thread(_next_stream_event, stream)
+            )
         try:
             event = await asyncio.wait_for(
-                asyncio.to_thread(_next_stream_event, stream),
+                asyncio.shield(pending),
                 timeout=0.1,
             )
         except asyncio.TimeoutError:
             continue
+        pending = None
 
         if event is None:
             return
@@ -971,17 +979,25 @@ async def _chat_event_generator(
     *, request_id: str, stream: Any, raw_request: Request
 ) -> Any:
     runtime_engine, _ = _ensure_runtime_ready()
+    pending: Optional["asyncio.Future[Optional[str]]"] = None
     while True:
         if await raw_request.is_disconnected():
             runtime_engine.abort_request(request_id)
+            if pending is not None:
+                _ = pending.cancel()
             return
+        if pending is None:
+            pending = asyncio.ensure_future(
+                asyncio.to_thread(_next_stream_event, stream)
+            )
         try:
             event = await asyncio.wait_for(
-                asyncio.to_thread(_next_stream_event, stream),
+                asyncio.shield(pending),
                 timeout=0.1,
             )
         except asyncio.TimeoutError:
             continue
+        pending = None
 
         if event is None:
             return
@@ -991,6 +1007,7 @@ async def _chat_event_generator(
 
 
 async def _engine_loop() -> None:
+    _logger.info("engine loop started")
     while (
         _engine_shutdown_event is not None
         and not _engine_shutdown_event.is_set()
@@ -999,18 +1016,23 @@ async def _engine_loop() -> None:
             await asyncio.sleep(0.01)
             continue
 
-        if engine.has_pending_requests():
-            if _decode_watchdog is not None:
-                _decode_watchdog.activate()
-            _ = engine.step()
-            if _decode_watchdog is not None:
-                _decode_watchdog.feed()
-            await asyncio.sleep(0)
-            continue
+        try:
+            if engine.has_pending_requests():
+                if _decode_watchdog is not None:
+                    _decode_watchdog.activate()
+                _ = engine.step()
+                if _decode_watchdog is not None:
+                    _decode_watchdog.feed()
+                await asyncio.sleep(0)
+                continue
 
-        if _decode_watchdog is not None:
-            _decode_watchdog.deactivate()
-        await asyncio.sleep(0.005)
+            if _decode_watchdog is not None:
+                _decode_watchdog.deactivate()
+            await asyncio.sleep(0.005)
+        except Exception as exc:
+            _logger.exception("engine loop step failed")
+            _health_state.set_unhealthy(f"engine loop failed: {exc}")
+            return
 
 
 def _ensure_engine_loop_running() -> None:

--- a/moe_infinity/models/qwen3_paged_attention.py
+++ b/moe_infinity/models/qwen3_paged_attention.py
@@ -59,6 +59,31 @@ class Qwen3PagedAttention(Qwen3MoeAttention):
         cls._paged_backend = None
         cls._attention_metadata = None
 
+    @staticmethod
+    def _valid_token_index(
+        metadata: object,
+        bsz: int,
+        q_len: int,
+        device: torch.device,
+    ) -> Optional[torch.Tensor]:
+        lengths = getattr(metadata, "lengths", None)
+        query_lengths = (
+            getattr(lengths, "query_lengths", None)
+            if lengths is not None
+            else None
+        )
+        if query_lengths is None:
+            return None
+        per_seq = [int(v) for v in query_lengths.reshape(-1).tolist()]
+        if len(per_seq) != bsz or all(length == q_len for length in per_seq):
+            return None
+        indices = [
+            row * q_len + col
+            for row, length in enumerate(per_seq)
+            for col in range(length)
+        ]
+        return torch.tensor(indices, dtype=torch.long, device=device)
+
     @deprecate_kwarg(
         "past_key_value", new_name="past_key_values", version="4.58"
     )
@@ -147,6 +172,15 @@ class Qwen3PagedAttention(Qwen3MoeAttention):
             .view(-1, num_key_value_heads, self.head_dim)
         )
 
+        valid_index = self._valid_token_index(
+            attention_metadata, bsz, q_len, query_tokens.device
+        )
+        packed = valid_index is not None
+        if packed:
+            query_tokens = query_tokens.index_select(0, valid_index)
+            key_tokens = key_tokens.index_select(0, valid_index)
+            value_tokens = value_tokens.index_select(0, valid_index)
+
         attn_output_tokens = paged_backend.forward(
             query_tokens,
             key_tokens,
@@ -155,6 +189,15 @@ class Qwen3PagedAttention(Qwen3MoeAttention):
             scale=cast(float, self.scaling),
             layer_idx=int(self.layer_idx),
         )
+
+        if packed and attn_output_tokens is not None:
+            scattered = attn_output_tokens.new_zeros(
+                bsz * q_len,
+                attn_output_tokens.shape[1],
+                attn_output_tokens.shape[2],
+            )
+            scattered.index_copy_(0, valid_index, attn_output_tokens)
+            attn_output_tokens = scattered
 
         if attn_output_tokens is None or attn_output_tokens.ndim != 3:
             raise ValueError(

--- a/moe_infinity/runtime/attention_backend.py
+++ b/moe_infinity/runtime/attention_backend.py
@@ -752,6 +752,9 @@ class PagedAttentionBackend:
                 self.spec.num_kv_heads,
                 self.spec.head_dim,
                 self.spec.block_size,
+                causal=True,
+                q_data_type=self.spec.dtype,
+                kv_data_type=self.spec.dtype,
             )
         except TypeError:
             self._fi_prefill.plan(
@@ -786,6 +789,9 @@ class PagedAttentionBackend:
                 self.spec.num_kv_heads,
                 self.spec.head_dim,
                 self.spec.block_size,
+                pos_encoding_mode="NONE",
+                q_data_type=query_dtype,
+                kv_data_type=query_dtype,
             )
         except TypeError:
             self._fi_decode.plan(

--- a/moe_infinity/runtime/flashinfer_utils.py
+++ b/moe_infinity/runtime/flashinfer_utils.py
@@ -16,7 +16,10 @@ except Exception:
 HAS_FLASHINFER: Final[bool] = _has_flashinfer
 
 
-_WORKSPACE_SIZE_BYTES = 128 * 1024 * 1024
+# Shared prefill+decode scratch: chunked append-attention split-KV scratch
+# (tmp_s/LSE/partial-O) grows with query rows and KV pages, overflowing the
+# 128 MiB FlashInfer example default on chunk 2; 256 MiB gives ~2x headroom.
+_WORKSPACE_SIZE_BYTES = 256 * 1024 * 1024
 _WORKSPACE_CACHE: dict[tuple[str, int | None], torch.Tensor] = {}
 
 

--- a/moe_infinity/serving/engine.py
+++ b/moe_infinity/serving/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from math import ceil
@@ -24,6 +25,8 @@ from .sequence import (
     SequenceGroup,
     SequenceStatus,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class EvictionSyncAdapter(Protocol):
@@ -862,16 +865,35 @@ class ContinuousBatchingEngine:
                     for module in modules
                 ]
             )
-            if (
-                backend.num_gpu_blocks >= self.kv_cache.num_blocks
-                and backend.block_store.physical_capacity
-                >= self.kv_cache.num_blocks
-            ):
-                self.kv_cache.set_block_store(
-                    backend.block_store,
-                    logical_capacity=self.kv_cache.num_blocks,
+            physical_capacity = min(
+                int(backend.num_gpu_blocks),
+                int(backend.block_store.physical_capacity),
+            )
+            if physical_capacity <= 0:
+                logger.warning(
+                    "layered paged KV store not bound: physical capacity "
+                    "is %d (num_gpu_blocks=%d, store_capacity=%d)",
+                    physical_capacity,
+                    backend.num_gpu_blocks,
+                    backend.block_store.physical_capacity,
                 )
-        except (ValueError, RuntimeError):
+                return
+            if self.kv_cache.num_blocks > physical_capacity:
+                logger.warning(
+                    "capping logical KV blocks %d -> %d to fit physical "
+                    "paged store (num_gpu_blocks=%d, store_capacity=%d)",
+                    self.kv_cache.num_blocks,
+                    physical_capacity,
+                    backend.num_gpu_blocks,
+                    backend.block_store.physical_capacity,
+                )
+                self.kv_cache.resize_num_blocks(physical_capacity)
+            self.kv_cache.set_block_store(
+                backend.block_store,
+                logical_capacity=self.kv_cache.num_blocks,
+            )
+        except (ValueError, RuntimeError) as exc:
+            logger.warning("failed to bind layered paged KV store: %r", exc)
             return
 
     def _execute_batch(self, batch: BatchMetadata) -> torch.Tensor:

--- a/moe_infinity/serving/kv_cache.py
+++ b/moe_infinity/serving/kv_cache.py
@@ -427,7 +427,17 @@ class PagedKVCache:
             raise ValueError("paged KV head-count mismatch")
         if store.head_dim != self.head_dim:
             raise ValueError("paged KV head-dimension mismatch")
-        if store.dtype != self.dtype or store.device != self.device:
+
+        def _dev_key(device: torch.device) -> tuple[str, int]:
+            if device.index is not None:
+                return (device.type, device.index)
+            if device.type == "cuda":
+                return (device.type, torch.cuda.current_device())
+            return (device.type, -1)
+
+        if store.dtype != self.dtype or _dev_key(store.device) != _dev_key(
+            self.device
+        ):
             raise ValueError("paged KV dtype/device mismatch")
         self._block_store = store
 

--- a/moe_infinity/serving/kv_cache.py
+++ b/moe_infinity/serving/kv_cache.py
@@ -256,6 +256,48 @@ class PagedKVCache:
                     self._fi_prefill = None
                     self._fi_decode = None
 
+    def resize_num_blocks(self, new_num_blocks: int) -> None:
+        """Shrink the logical block budget to fit the physical paged store.
+
+        Only shrinks, and only before any sequence is allocated: it rebuilds
+        the allocator and logical KV tensor, which would invalidate live block
+        ids. See :meth:`set_block_store`, which requires logical <= physical.
+        """
+        if new_num_blocks <= 0:
+            raise ValueError(
+                f"new_num_blocks must be > 0, got {new_num_blocks}"
+            )
+        if self._sequence_tables:
+            raise RuntimeError(
+                "cannot resize KV blocks while sequences are allocated"
+            )
+        if new_num_blocks == self.num_blocks:
+            return
+        if new_num_blocks > self.num_blocks:
+            raise ValueError(
+                "resize_num_blocks only shrinks the logical budget "
+                f"({new_num_blocks} > {self.num_blocks})"
+            )
+
+        self.num_blocks = int(new_num_blocks)
+        self.block_allocator = BlockAllocator(
+            num_blocks=self.num_blocks,
+            block_size=self.block_size,
+            device=self.device,
+        )
+        self._kv_cache = torch.zeros(
+            (
+                self.num_layers,
+                self.num_blocks,
+                2,
+                self.block_size,
+                self.num_heads,
+                self.head_dim,
+            ),
+            dtype=self.dtype,
+            device=self.device,
+        )
+
     def allocate_sequence(self, seq_id: int, num_tokens: int) -> None:
         if seq_id in self._sequence_tables:
             raise ValueError(f"sequence {seq_id} already exists")

--- a/moe_infinity/serving/scheduler.py
+++ b/moe_infinity/serving/scheduler.py
@@ -795,6 +795,9 @@ class Scheduler:
                 )
                 try:
                     self.kv_cache.append_tokens(seq_id, num_new_tokens=num_new)
+                    self.kv_cache.ensure_sequence_capacity(
+                        seq_id, sequence.num_computed_tokens + 1
+                    )
                 except KeyError:
                     pass
 


### PR DESCRIPTION
Completes chunked prefill (#178). Stacks on **#189** (`fix/serving-streaming-and-flashinfer-dtype`); merge #189 first.

## Fixes
1. **KV block-budget reconciliation** — the logical KV allocator and the physical paged store were budgeted independently, so the logical count could exceed the store; `_bind_layered_paged_kv_store` then failed its capacity gate and swallowed the error, leaving `block_store` unbound and crashing `_schedule_chunked_prefill` ("layered paged KV store is not bound"). Now caps logical→physical before binding (`PagedKVCache.resize_num_blocks`), guards per-sequence decode capacity, and logs the real reason instead of a bare `except`.
2. **FlashInfer workspace** — chunked append-attention split-KV scratch overflowed the 128 MiB default on chunk 2; raised the shared prefill+decode workspace to 256 MiB.
3. **Ragged query packing** — concurrent requests with heterogeneous query lengths padded every sequence to `q_len`, feeding padding tokens to the paged backend; now packs valid tokens per `query_lengths` and scatters results back.

## Verification (Qwen3-30B-A3B, sm120, FlashInfer 0.6.18)
- Chunked prefill runs end-to-end: short + 1000-tok (4 chunks) + **4096-tok (16 chunks) + decode**.
- Whole-prefill **non-regressing** (store binding now also covers it).
- A/B (`benchmarks/serving/chunked_prefill_latency.py`) **passed** with `output_parity=True` (`178_ab.json`).

## Known pre-existing limitation (out of scope)
Whole-prefill hangs on prompts > `max_tokens_per_step` (2048) — the exact case chunked prefill solves; tracked separately.