### PR TITLE
fix(dispatcher): stream-order expert exec against input producer and consumers

### DIFF
--- a/core/parallel/expert_dispatcher.cpp
+++ b/core/parallel/expert_dispatcher.cpp
@@ -131,6 +131,9 @@ ExpertDispatcher::ExpertDispatcher(int num_experts, int num_layers, int dtype,
     cudaStream_t exec_stream;
     cudaStreamCreateWithFlags(&exec_stream, cudaStreamNonBlocking);
     exec_streams_.emplace_back(exec_stream);
+    cudaEvent_t exec_done_event;
+    cudaEventCreateWithFlags(&exec_done_event, cudaEventDisableTiming);
+    exec_done_events_.emplace_back(exec_done_event);
 
     modules_[i] = new MoEMLP(dtype, expert_type);
 
@@ -616,6 +619,17 @@ void ExpertDispatcher::GPUExecFunc(int gpu_id, int thread_idx) {
       auto device = CUDA_DEVICE(gpu_id);
       auto expert_idx = args.expert_node->expert_idx;
 
+      // Enter the exec stream before any tensor op and order it after the
+      // producer stream that wrote hidden_states_/router_mask_ (recorded in
+      // SetInputs). exec streams are non-blocking, so without this the
+      // gather/copy below could run against not-yet-written input memory.
+      c10::cuda::CUDAStream torch_stream =
+          c10::cuda::getStreamFromExternal(stream, gpu_id);
+      c10::cuda::CUDAStreamGuard guard(torch_stream);
+      if (input_ready_event_ != nullptr) {
+        cudaStreamWaitEvent(stream, input_ready_event_, 0);
+      }
+
       auto token_mask = router_mask_.index({"...", expert_idx});
       torch::Tensor input = (batch_size == 1)
                                 ? hidden_states_.to(device)
@@ -634,10 +648,6 @@ void ExpertDispatcher::GPUExecFunc(int gpu_id, int thread_idx) {
           modules_[thread_idx]->DequantFp8Params(stream);
         }
       }
-
-      c10::cuda::CUDAStream torch_stream =
-          c10::cuda::getStreamFromExternal(stream, gpu_id);
-      c10::cuda::CUDAStreamGuard guard(torch_stream);
 
       if (expert_type_ == GPT_OSS_MOE_DENSE_ACT_DENSE) {
         modules_[thread_idx]->DequantMxfp4Params(stream);
@@ -721,6 +731,7 @@ std::vector<ExpertDispatcher::CallResult> ExpertDispatcher::Wait() {
 
   std::unique_lock<std::mutex> lock(pending_mutex_);
   pending_cv_.wait(lock, [&] { return pending_.load() == 0; });
+  SyncExecStreamsWithCurrent();
 
   num_enqueued_.store(0);
   std::vector<CallResult> output_queue;
@@ -738,6 +749,10 @@ torch::Tensor ExpertDispatcher::WaitHiddenStates() {
 #endif
   std::unique_lock<std::mutex> lock(pending_mutex_);
   pending_cv_.wait(lock, [&] { return pending_.load() == 0; });
+  // pending_ hits zero when the accumulation is enqueued, not complete;
+  // order the caller's stream after every exec stream before the result
+  // tensor is consumed.
+  SyncExecStreamsWithCurrent();
   num_enqueued_.store(0);
   return final_hidden_states_;
 }
@@ -752,4 +767,17 @@ void ExpertDispatcher::SetInputs(const torch::Tensor& hidden_states,
   router_mask_ = router_mask;
   router_weight_ = router_weight;  // this can be float32
   final_hidden_states_ = torch::zeros_like(hidden_states, options);
+
+  if (input_ready_event_ == nullptr) {
+    cudaEventCreateWithFlags(&input_ready_event_, cudaEventDisableTiming);
+  }
+  cudaEventRecord(input_ready_event_, c10::cuda::getCurrentCUDAStream());
+}
+
+void ExpertDispatcher::SyncExecStreamsWithCurrent() {
+  auto current = c10::cuda::getCurrentCUDAStream();
+  for (size_t i = 0; i < exec_streams_.size(); ++i) {
+    cudaEventRecord(exec_done_events_[i], exec_streams_[i]);
+    cudaStreamWaitEvent(current.stream(), exec_done_events_[i], 0);
+  }
 }

--- a/core/parallel/expert_dispatcher.h
+++ b/core/parallel/expert_dispatcher.h
@@ -91,6 +91,12 @@ class ExpertDispatcher : public base::noncopyable {
     for (auto& stream : fetch_streams_) {
       cudaStreamDestroy(stream);
     }
+    for (auto& event : exec_done_events_) {
+      cudaEventDestroy(event);
+    }
+    if (input_ready_event_ != nullptr) {
+      cudaEventDestroy(input_ready_event_);
+    }
     for (auto* m : modules_) {
       delete m;
     }
@@ -171,7 +177,11 @@ class ExpertDispatcher : public base::noncopyable {
   std::mutex output_mutex_;
   std::mutex accum_mutex_;
 
+  void SyncExecStreamsWithCurrent();
+
   std::vector<cudaStream_t> exec_streams_;
+  std::vector<cudaEvent_t> exec_done_events_;
+  cudaEvent_t input_ready_event_ = nullptr;
   std::vector<cudaStream_t> fetch_streams_;
 
   std::unique_ptr<std::atomic<bool>[]> gpu_overload_;


### PR DESCRIPTION
## Problem
Two unordered cross-stream handoffs in `ExpertDispatcher` (all branches inherit this from `dev`):

1. **Input race** — `GPUExecFunc` built the expert input (`router_mask_.index`, `hidden_states_.to`) on the thread's default torch stream, then ran the expert kernel on a `cudaStreamNonBlocking` exec stream. Non-blocking streams have no implicit ordering with the default stream, so the kernel could read the input buffer before the gather/copy landed.
2. **Output race** — `Wait()`/`WaitHiddenStates()` returned when `pending_` reached zero, which happens when the accumulation is *enqueued* on the exec stream, not when it completes. Callers could consume `final_hidden_states_` while `index_add_`/`add_` were still in flight.

## Evidence
Deterministic repro via NaN-poisoning the torch caching allocator before engine construction (uninitialized reads become visible): prefix-enabled Qwen3-30B-A3B serving on RTX PRO 6000 (sm120) produced **100%-NaN logits from prefill step 0**, with `layers[0].mlp` receiving finite input, all dense params finite, and attention outputs finite — i.e. corruption inside expert dispatch. The same config was sane in a different harness (timing-dependent). This race is the likely root cause of the "warm ≠ cold tokens" observation that put PR #190 on HOLD.

## Fix
- `SetInputs` records `input_ready_event_` on the producing stream; each exec iteration enters the exec-stream guard **before any tensor op** and waits on that event.
- `Wait()`/`WaitHiddenStates()` enqueue exec-stream completion waits onto the caller's current stream via per-exec-stream events (no host sync added).

## Validation (sm120, Qwen3-30B-A3B, 64+8-token prefix parity suite)
- Poisoned repro: finite end-to-end, tokens bitwise-equal to the reference.
- `enabled_cold` (prefix bound, zero reuse) is now **bitwise-identical** to `disabled` (token digest `e37a9d14`, logits Δ = 0.0). Before: 100% NaN.
- Warm reuse remains subject to near-tie argmax swaps from cross-kernel bf16 numerics + accumulation-order nondeterminism (`final_hidden_states_.add_` completion order; pre-existing, mode-independent) — characterized in PR #190.

Related: #176 (stream-ordered completion roadmap), #190 (prefix-reuse HOLD evidence).