### PR TITLE
fix(kernel): raise expert-module token cap to 8192

### DIFF
--- a/core/parallel/expert_module.cpp
+++ b/core/parallel/expert_module.cpp
@@ -15,7 +15,7 @@ extern void fp8_dequant_blockwise_cuda(const void* weight, const void* scale,
                                        void* out, int N, int K,
                                        cudaStream_t stream);
 
-static const int64_t kMaxTokens = 256;
+static const int64_t kMaxTokens = 8192;
 
 void ExpertNode::SetTensorsFromBlob(const torch::Device& device) {
   auto expert_type = static_cast<ExpertType>(this->expert_type);


### PR DESCRIPTION
kMaxTokens=256 hard-aborts any step whose scheduled token count exceeds 256 (TORCH_CHECK in expert_module.cpp), which concurrent-batch serving hits immediately — reproduced during #188 GPU validation (4×256-token prompts → 280 tokens → SIGABRT). Raising to 8192 (the serving max_tokens_per_step default ceiling). Validated on sm120: with the bump, the same workload completes cleanly (see #188 validation comment). The buffer this sizes is a per-module data shape, so host/GPU footprint impact is bounded and only materializes per expert module instance.