### PR TITLE
ci: grant claude-review write perms + gh comment allow-list so reviews actually post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -40,5 +40,9 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # The code-review plugin posts its findings through gh; without this
+          # allow-list (and pull-requests/issues write perms above) the agent
+          # finishes with permission denials and no review ever appears.
+          claude_args: '--allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue comment:*)"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
The Claude Code Review workflow has never posted a review: the job's app token had `pull-requests: read` / `issues: read` (cannot post), and the agent had no `--allowedTools` for `gh pr comment` — every run ended with `permission_denials_count > 0` and *No buffered inline comments* (verified in run logs for #199/#200/#201, incl. after `CLAUDE_CODE_OAUTH_TOKEN` was configured).

This grants `pull-requests: write` + `issues: write` and allow-lists `gh pr comment/diff/view` + `gh issue comment`.

**Why a dedicated PR:** claude-code-action refuses workflow-file changes coming from a PR branch — *"the workflow file must have identical content to the version on the repository's default branch"* — so this must merge to `main` first. #199/#200/#201 branches already carry the identical commit, so their reviews start working immediately after this merges (re-run their `Claude Code Review` workflow runs or push any commit).