### PR TITLE
fix: gate FlashInfer to head_dim in {64,128}; align test fixtures (#196)

### DIFF
--- a/moe_infinity/runtime/attention_backend.py
+++ b/moe_infinity/runtime/attention_backend.py
@@ -34,6 +34,8 @@ from moe_infinity.runtime.kv_cache_format import (
     resolve_kv_cache_format,
 )
 
+_FLASHINFER_SUPPORTED_HEAD_DIMS = frozenset({64, 128})
+
 __all__ = [
     "FlashInferPlanMetadata",
     "LayerRegistration",
@@ -427,7 +429,15 @@ class PagedAttentionBackend:
         self._fi_kv_cache = None
         self._fi_prefill = None
         self._fi_decode = None
-        if not self._is_int8 and flashinfer_utils.HAS_FLASHINFER:
+        # MLA runs with a padded head_dim (256); FlashInfer's paged wrappers
+        # JIT-compile per head_dim on first use and stall the request there, so
+        # only small standard dims use FlashInfer. MLA falls back to SDPA
+        # prefill + the precompiled paged_attention_v1 kernel (both handle 256).
+        if (
+            not self._is_int8
+            and flashinfer_utils.HAS_FLASHINFER
+            and spec.head_dim in _FLASHINFER_SUPPORTED_HEAD_DIMS
+        ):
             flashinfer_module = cast(
                 Any,
                 flashinfer_utils.get_flashinfer_module(),

--- a/tests/python/serving/test_flashinfer_model_runner.py
+++ b/tests/python/serving/test_flashinfer_model_runner.py
@@ -286,7 +286,7 @@ def _make_transactional_backend(
     backend = PagedAttentionBackend(
         spec=KVCacheSpec(
             num_kv_heads=2,
-            head_dim=8,
+            head_dim=64,
             dtype=torch.float16,
             block_size=block_size,
         ),

--- a/tests/python/serving/test_qwen3_paged_attention_cuda.py
+++ b/tests/python/serving/test_qwen3_paged_attention_cuda.py
@@ -25,7 +25,7 @@ def test_real_qwen3_paged_attention_runs_chunk_through_flashinfer() -> None:
         hidden_size=32,
         num_attention_heads=4,
         num_key_value_heads=2,
-        head_dim=8,
+        head_dim=64,
         num_hidden_layers=1,
         intermediate_size=64,
         moe_intermediate_size=16,
@@ -38,14 +38,14 @@ def test_real_qwen3_paged_attention_runs_chunk_through_flashinfer() -> None:
         .eval()
     )
     backend = PagedAttentionBackend(
-        spec=KVCacheSpec(2, 8, torch.float16, 4),
+        spec=KVCacheSpec(2, 64, torch.float16, 4),
         num_gpu_blocks=4,
         num_layers=1,
         device=device,
     )
     assert backend._flashinfer_enabled()
     backend.register_layers([LayerRegistration(0, id(attention))])
-    prefix_k = torch.randn(4, 2, 8, device=device, dtype=torch.float16)
+    prefix_k = torch.randn(4, 2, 64, device=device, dtype=torch.float16)
     prefix_v = torch.randn_like(prefix_k)
     prefix_slots = torch.arange(4, device=device)
     backend.write_kv(prefix_k, prefix_v, prefix_slots, layer_idx=0)
@@ -67,8 +67,8 @@ def test_real_qwen3_paged_attention_runs_chunk_through_flashinfer() -> None:
         is_prefill=True,
     )
     hidden = torch.randn(1, 2, 32, device=device, dtype=torch.float16)
-    cos = torch.ones(1, 2, 8, device=device, dtype=torch.float16)
-    sin = torch.zeros(1, 2, 8, device=device, dtype=torch.float16)
+    cos = torch.ones(1, 2, 64, device=device, dtype=torch.float16)
+    sin = torch.zeros(1, 2, 64, device=device, dtype=torch.float16)
     Qwen3PagedAttention.set_paged_context(backend, metadata)
     try:
         output, weights = attention(

--- a/tests/python/unit/test_flashinfer_attention_backend.py
+++ b/tests/python/unit/test_flashinfer_attention_backend.py
@@ -26,7 +26,7 @@ def _make_layered_store(
         num_blocks=num_blocks,
         block_size=4,
         num_kv_heads=2,
-        head_dim=8,
+        head_dim=64,
         execution_dtype=torch.float32,
         device=torch.device("cpu"),
     )
@@ -75,7 +75,7 @@ class _FakeDecodeWrapper:
 def _spec() -> KVCacheSpec:
     return KVCacheSpec(
         num_kv_heads=2,
-        head_dim=8,
+        head_dim=64,
         dtype=torch.float32,
         block_size=4,
     )
@@ -151,7 +151,7 @@ def test_flashinfer_kv_cache_layout_nhd_with_mocked_module(
         device=torch.device("cpu"),
     )
     assert backend._fi_kv_cache is not None
-    assert backend._fi_kv_cache.shape == (10, 2, 4, 2, 8)
+    assert backend._fi_kv_cache.shape == (10, 2, 4, 2, 64)
 
 
 def test_flashinfer_prefill_metadata_is_int32_with_mocked_module(
@@ -164,9 +164,9 @@ def test_flashinfer_prefill_metadata_is_int32_with_mocked_module(
         device=torch.device("cpu"),
     )
 
-    query = torch.randn(4, 4, 8)
-    key = torch.randn(4, 2, 8)
-    value = torch.randn(4, 2, 8)
+    query = torch.randn(4, 4, 64)
+    key = torch.randn(4, 2, 64)
+    value = torch.randn(4, 2, 64)
     out = backend.forward(
         query=query,
         key=key,
@@ -174,7 +174,7 @@ def test_flashinfer_prefill_metadata_is_int32_with_mocked_module(
         attention_metadata=_prefill_metadata(num_tokens=4),
     )
 
-    assert out.shape == (4, 4, 8)
+    assert out.shape == (4, 4, 64)
     assert backend._fi_prefill is not None
     assert backend._fi_prefill.plan_args is not None
     plan_args = backend._fi_prefill.plan_args[0]
@@ -194,8 +194,8 @@ def test_flashinfer_decode_metadata_is_int32_with_mocked_module(
         device=torch.device("cpu"),
     )
 
-    key = torch.randn(4, 2, 8)
-    value = torch.randn(4, 2, 8)
+    key = torch.randn(4, 2, 64)
+    value = torch.randn(4, 2, 64)
     backend.write_kv_flashinfer(
         key=key,
         value=value,
@@ -203,12 +203,12 @@ def test_flashinfer_decode_metadata_is_int32_with_mocked_module(
     )
 
     out = backend.forward(
-        query=torch.randn(1, 4, 8),
+        query=torch.randn(1, 4, 64),
         key=key[:1],
         value=value[:1],
         attention_metadata=_decode_metadata(seq_len=4),
     )
-    assert out.shape == (1, 4, 8)
+    assert out.shape == (1, 4, 64)
     assert backend._fi_decode is not None
     assert backend._fi_decode.plan_args is not None
     plan_args = backend._fi_decode.plan_args[0]
@@ -227,7 +227,7 @@ def test_write_kv_flashinfer_writes_expected_layout(
         device=torch.device("cpu"),
     )
 
-    key = torch.arange(3 * 2 * 8, dtype=torch.float32).reshape(3, 2, 8)
+    key = torch.arange(3 * 2 * 64, dtype=torch.float32).reshape(3, 2, 64)
     value = key + 1000.0
     slot_mapping = torch.tensor([0, 3, 4], dtype=torch.long)
 
@@ -260,12 +260,12 @@ def test_fallback_prefill_without_flashinfer(
     )
 
     out = backend.forward(
-        query=torch.randn(4, 4, 8),
-        key=torch.randn(4, 2, 8),
-        value=torch.randn(4, 2, 8),
+        query=torch.randn(4, 4, 64),
+        key=torch.randn(4, 2, 64),
+        value=torch.randn(4, 2, 64),
         attention_metadata=_prefill_metadata(num_tokens=4),
     )
-    assert out.shape == (4, 4, 8)
+    assert out.shape == (4, 4, 64)
     assert backend._fi_prefill is None
 
 
@@ -282,17 +282,17 @@ def test_fallback_decode_without_flashinfer(
         num_gpu_blocks=10,
         device=torch.device("cpu"),
     )
-    key = torch.randn(4, 2, 8)
-    value = torch.randn(4, 2, 8)
+    key = torch.randn(4, 2, 64)
+    value = torch.randn(4, 2, 64)
     backend.write_kv(key=key, value=value, slot_mapping=torch.arange(4))
 
     out = backend.forward(
-        query=torch.randn(1, 4, 8),
+        query=torch.randn(1, 4, 64),
         key=key[:1],
         value=value[:1],
         attention_metadata=_decode_metadata(seq_len=4),
     )
-    assert out.shape == (1, 4, 8)
+    assert out.shape == (1, 4, 64)
     assert backend._fi_decode is None
 
 
@@ -318,9 +318,9 @@ def test_flashinfer_qo_indptr_uses_chunk_queries_not_total_kv(
         is_prefill=True,
     )
     backend.forward(
-        query=torch.randn(5, 4, 8),
-        key=torch.randn(5, 2, 8),
-        value=torch.randn(5, 2, 8),
+        query=torch.randn(5, 4, 64),
+        key=torch.randn(5, 2, 64),
+        value=torch.randn(5, 2, 64),
         attention_metadata=metadata,
     )
 
@@ -337,7 +337,7 @@ def _make_serving_cache(num_blocks: int, block_size: int) -> PagedKVCache:
         block_size=block_size,
         num_layers=1,
         num_heads=2,
-        head_dim=8,
+        head_dim=64,
         dtype=torch.float32,
         device=torch.device("cpu"),
     )
@@ -352,8 +352,8 @@ def test_layered_store_checkpoint_restores_both_layouts(
     )
     backend.create_layered_store(layer_count=1)
     checkpoint = backend.block_store.checkpoint([1])
-    key = torch.full((2, 2, 8), 7.0)
-    value = torch.full((2, 2, 8), 9.0)
+    key = torch.full((2, 2, 64), 7.0)
+    value = torch.full((2, 2, 64), 9.0)
     slots = torch.tensor([4, 5])
     backend.write_kv(key, value, slots)
     backend.write_kv_flashinfer(key, value, slots)
@@ -377,7 +377,7 @@ def test_swap_exports_and_restores_runtime_backend_storage(
     cache = _make_serving_cache(num_blocks=4, block_size=4)
     cache.set_block_store(backend.block_store, owner=backend)
     cache.allocate_sequence(3, num_tokens=4)
-    key = torch.arange(64, dtype=torch.float32).reshape(4, 2, 8)
+    key = torch.arange(4 * 2 * 64, dtype=torch.float32).reshape(4, 2, 64)
     value = key + 100.0
     backend.write_kv(key, value, torch.arange(4))
     backend.write_kv_flashinfer(key, value, torch.arange(4))
@@ -388,10 +388,10 @@ def test_swap_exports_and_restores_runtime_backend_storage(
 
     restored = backend.block_store.export_blocks(cache.get_block_table(3))
     torch.testing.assert_close(
-        restored.fi_kv_cache[0, :, 0], key.reshape(1, 4, 2, 8)
+        restored.fi_kv_cache[0, :, 0], key.reshape(1, 4, 2, 64)
     )
     torch.testing.assert_close(
-        restored.fi_kv_cache[0, :, 1], value.reshape(1, 4, 2, 8)
+        restored.fi_kv_cache[0, :, 1], value.reshape(1, 4, 2, 64)
     )
 
 
@@ -430,7 +430,7 @@ def make_recording_backend(monkeypatch: pytest.MonkeyPatch):
         flashinfer_utils, "get_workspace", lambda device: torch.empty(1)
     )
     spec = KVCacheSpec(
-        num_kv_heads=2, head_dim=8, dtype=torch.float16, block_size=16
+        num_kv_heads=2, head_dim=64, dtype=torch.float16, block_size=16
     )
     backend = PagedAttentionBackend(
         spec, num_gpu_blocks=16, device=torch.device("cpu")
@@ -463,7 +463,7 @@ def make_slots(
 
 
 def make_q(tokens: int) -> torch.Tensor:
-    return torch.zeros(tokens, 2, 8, dtype=torch.float16)
+    return torch.zeros(tokens, 2, 64, dtype=torch.float16)
 
 
 make_k = make_q
@@ -523,7 +523,7 @@ def test_export_import_checkpoint_restore_cover_every_layer(
 ) -> None:
     _enable_fake_flashinfer(monkeypatch)
     backend = attention_backend_module.PagedAttentionBackend(
-        spec=KVCacheSpec(2, 8, torch.float16, 4),
+        spec=KVCacheSpec(2, 64, torch.float16, 4),
         num_gpu_blocks=4,
         device=torch.device("cpu"),
     )
@@ -556,7 +556,7 @@ def test_flashinfer_workspace_reuse_across_batches() -> None:
     backend = attention_backend_module.PagedAttentionBackend(
         spec=KVCacheSpec(
             num_kv_heads=2,
-            head_dim=16,
+            head_dim=64,
             dtype=torch.float16,
             block_size=4,
         ),
@@ -581,9 +581,9 @@ def test_flashinfer_workspace_reuse_across_batches() -> None:
         is_prefill=True,
     )
 
-    query = torch.randn(4, 4, 16, dtype=torch.float16, device="cuda")
-    key = torch.randn(4, 2, 16, dtype=torch.float16, device="cuda")
-    value = torch.randn(4, 2, 16, dtype=torch.float16, device="cuda")
+    query = torch.randn(4, 4, 64, dtype=torch.float16, device="cuda")
+    key = torch.randn(4, 2, 64, dtype=torch.float16, device="cuda")
+    value = torch.randn(4, 2, 64, dtype=torch.float16, device="cuda")
 
     workspace0 = backend._fi_workspace
     backend.forward(


### PR DESCRIPTION
## Summary

Standalone fix for #196, extracted from the larger PR #195 (`feat/deepseek-mla-paged-attention`) so it can land on `main` independently and go green now.

Gates FlashInfer to standard head dims `{64, 128}` and aligns the mocked-FlashInfer test fixtures that had drifted to `head_dim=8/16`.

## Why

FlashInfer's paged prefill/decode wrappers JIT-compile per `head_dim` on first use and stall the request on MLA's padded `head_dim` (256). We restrict FlashInfer to the standard head dims `{64, 128}`; anything else falls back to SDPA prefill + the precompiled `paged_attention_v1` kernel (both handle 256).

Adding the gate exposed pre-existing **test/code drift**: the mocked-FlashInfer fixtures built backends with `head_dim=8/16`, which the gate now (correctly) routes to the fallback path — leaving `_fi_kv_cache`/`_fi_prefill`/`_fi_decode` as `None` and failing the FlashInfer-path assertions (the exact failures reported in #196). The fixtures are bumped to `head_dim=64` so they exercise the path they assert.

## Changes

- `moe_infinity/runtime/attention_backend.py`: add `_FLASHINFER_SUPPORTED_HEAD_DIMS = {64, 128}` and gate FlashInfer init on it (preserves the existing `not self._is_int8` guard and main's 5-dim `_fi_kv_cache` layout).
- `tests/python/unit/test_flashinfer_attention_backend.py`: fixtures `head_dim` 8→64 (+ expected shapes).
- `tests/python/serving/test_flashinfer_model_runner.py`: transactional-backend fixture `head_dim` 8→64.
- `tests/python/serving/test_qwen3_paged_attention_cuda.py`: fixture `head_dim` 8→64 (CUDA + real-FlashInfer gated; skipped in CI).

## Verification (CPU-only, `CUDA_VISIBLE_DEVICES=""`)

- `tests/python/unit/test_flashinfer_attention_backend.py`: **14 passed, 1 skipped** (CUDA-gated).
- Full `tests/python/unit` + `tests/python/serving`: **937 passed, 55 skipped, 1 failed**.
- The one unit/serving failure (`test_glm_moe_dsa.py::test_glm_cpp_dequant_matches_python`, missing `_store.dequant_fp8_blockwise` symbol) and the integration/ops failures (`test_topology_runtime_parity`, `test_paged_kv_write::test_second_decode_token_eager_observes_first_token_kv`) reproduce **identically with these changes stashed** — they are pre-existing/local-build artifacts, not introduced here.

Fixes #196
