### PR TITLE
Fix Jamba expert type mapping: 4 to 5 (JambaMLP layout)

### DIFF
--- a/moe_infinity/common/constants.py
+++ b/moe_infinity/common/constants.py
@@ -50,7 +50,8 @@ MODEL_MAPPING_TYPES = {
     "qwen3": 5,
     "dbrx": 4,
     "olmoe": 4,
-    "jamba": 4,
+    # JambaMLP registers gate_proj, up_proj, down_proj (not w1, w2, w3).
+    "jamba": 5,
 }
 
 # DeepSeek-V4 support depends on a transformers build that ships

--- a/moe_infinity/models/jamba.py
+++ b/moe_infinity/models/jamba.py
@@ -62,4 +62,8 @@ class SyncJambaMoEBlock(nn.Module):
         final_hidden_states = final_hidden_states.view(
             batch_size, sequence_length, hidden_dim
         ).to(hidden_states.dtype)
-        return final_hidden_states, router_logits
+        # transformers v5 decoder layers consume feed_forward(...) as a bare
+        # tensor: `hidden_states = residual + hidden_states`. Returning the
+        # v4 (tensor, router_logits) tuple makes that addition raise
+        # `TypeError: unsupported operand type(s) for +: 'Tensor' and 'tuple'`.
+        return final_hidden_states

--- a/tests/python/unit/test_jamba_expert_layout.py
+++ b/tests/python/unit/test_jamba_expert_layout.py
@@ -1,0 +1,55 @@
+"""CPU registration contract only; no native CUDA execution or weights."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _native_weight_names(expert_type):
+    header = (
+        Path(__file__).resolve().parents[3] / "core/parallel/expert_module.h"
+    ).read_text()
+    enum = re.search(rf"\b(\w+)\s*=\s*{expert_type}\s*[,}}]", header)
+    assert enum, f"Missing native expert type {expert_type}"
+    traits = re.search(
+        rf"struct ExpertTraits<ExpertType::{enum.group(1)}>\s*\{{"
+        r"(.*?)\n\};",
+        header,
+        re.S,
+    )
+    assert traits, "Native ExpertTraits declaration changed"
+    weights = re.search(r"weight_names\s*=\s*\{(.*?)\}", traits.group(1), re.S)
+    assert weights, "Native weight registration declaration changed"
+    return re.findall(r'"([^\"]+)"', weights.group(1))
+
+
+def test_jamba_registration_matches_native_expert_layout():
+    modeling = pytest.importorskip("transformers.models.jamba.modeling_jamba")
+    if not hasattr(modeling, "JambaMLP"):
+        pytest.skip("transformers does not expose JambaMLP")
+    from transformers import JambaConfig
+
+    from moe_infinity.common.constants import parse_expert_type
+    from moe_infinity.models.jamba import SyncJambaMoEBlock
+
+    config = JambaConfig(
+        hidden_size=16,
+        intermediate_size=40,
+        num_experts=2,
+        num_experts_per_tok=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        architectures=["JambaForCausalLM"],
+    )
+    block = SyncJambaMoEBlock(config)
+    expected = _native_weight_names(parse_expert_type(config))
+    for expert in block.experts:
+        assert isinstance(expert, modeling.JambaMLP)
+        parameters = list(expert.named_parameters())
+        names = [name.removesuffix(".weight") for name, _ in parameters]
+        assert names == expected
+        # Unequal dimensions expose an up/down slot swap; these are real
+        # registered weights, not a mirrored architecture-to-type table.
+        assert expert.up_proj.weight.shape == (40, 16)
+        assert expert.down_proj.weight.shape == (16, 40)

--- a/tests/python/unit/test_jamba_return_contract.py
+++ b/tests/python/unit/test_jamba_return_contract.py
@@ -1,0 +1,59 @@
+"""Return-contract test: the wrapper must satisfy transformers v5 decoder layers.
+
+transformers v5's ``JambaDecoderLayer.forward`` does
+``hidden_states = residual + self.feed_forward(hidden_states)`` — a bare
+tensor. The v4 contract returned ``(hidden_states, router_logits)`` and would
+raise ``TypeError: unsupported operand type(s) for +: 'Tensor' and 'tuple'``.
+Registration-layout tests cannot see this; this test can.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+modeling = pytest.importorskip("transformers.models.jamba.modeling_jamba")
+
+if not hasattr(modeling, "JambaMLP"):
+    pytest.skip("transformers does not expose JambaMLP", allow_module_level=True)
+
+
+def test_forward_returns_bare_tensor():
+    """SyncJambaMoEBlock.forward must return a bare (batch, seq, hidden) tensor.
+
+    A stubbed expert_executor isolates the wrapper's own contract from the
+    distributed execution layer: dispatch_local is a no-op and
+    wait_dispatch_local returns an identity-shaped payload.
+    """
+    from transformers import JambaConfig
+
+    from moe_infinity.models.jamba import SyncJambaMoEBlock
+
+    config = JambaConfig(
+        hidden_size=16,
+        intermediate_size=40,
+        num_experts=2,
+        num_experts_per_tok=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        architectures=["JambaForCausalLM"],
+    )
+    block = SyncJambaMoEBlock(config)
+
+    hidden_states = torch.randn(2, 5, config.hidden_size)
+    flat = hidden_states.view(-1, config.hidden_size).clone()
+
+    block.expert_executor = SimpleNamespace(
+        dispatch_local=lambda *args, **kwargs: None,
+        wait_dispatch_local=lambda: flat,
+    )
+
+    out = block(hidden_states)
+
+    assert isinstance(out, torch.Tensor), (
+        "feed_forward must return a bare tensor for transformers v5 "
+        f"'residual + hidden_states'; got {type(out)}"
+    )
+    assert out.shape == hidden_states.shape
+    # And the result must survive the decoder layer's own arithmetic.
+    _ = hidden_states + out

--- a/tests/python/unit/test_model_registry.py
+++ b/tests/python/unit/test_model_registry.py
@@ -64,7 +64,7 @@ def test_parse_expert_type_new_models():
     for arch_prefix, expected_type in [
         ("DbrxForCausalLM", 4),
         ("OlmoeForCausalLM", 4),
-        ("JambaForCausalLM", 4),
+        ("JambaForCausalLM", 5),
     ]:
         config = SimpleNamespace(architectures=[arch_prefix])
         result = parse_expert_type(cast(Any, config))


### PR DESCRIPTION
Follow-up to the layout discussion in #205 (Jamba half of the agreed split; @danielesalpietro owns the separate OLMoE correction).

**Change:** `MODEL_MAPPING_TYPES["jamba"]` 4 → 5. Jamba experts are real `JambaMLP` modules registering `gate_proj` / `up_proj` / `down_proj`, matching the type-5 specialization `ExpertTraits<ExpertType::DeepSeekMoeDenseActDense>` (`weight_names = {gate_proj, up_proj, down_proj}`, `num_weights = 3`), not the type-4 w1/w2/w3 layout. *(Correction per @danielesalpietro's review: the original text cited `ExpertTraits<ExpertType::JAMBA_MOE>` "(5 weights)" — that specialization does not exist on `main`, and the parenthetical conflated the enum value 5 with a weight count. The change itself is unaffected.)*

**Regression added:** `tests/python/unit/test_jamba_expert_layout.py` builds a tiny `JambaConfig` (hidden 16, intermediate 40 — deliberately unequal so an up/down slot swap cannot pass), instantiates the actual `SyncJambaMoEBlock` experts, and asserts parameter names **and order** against the native `ExpertTraits` weight list parsed from `core/parallel/expert_module.h`. The oracle is the real registered module plus the native header — not a mirrored architecture-to-type table. Skips explicitly (never silently) when `transformers.models.jamba` is unavailable.

*Caveat carried over from review, for the record: `MoEMLP::ForwardHelper` never consults `ExpertTraits` — the fused path reads `param_` positionally (`core/parallel/expert_module.cpp:281-285`). The test's header oracle and the positional reads are two parallel representations that currently agree; if they ever drift, this test keeps passing. Documenting that coupling boundary here rather than claiming the test covers it.*

**Return contract fix (second commit `b48e0f4`):** transformers v5's `JambaDecoderLayer.forward` consumes `feed_forward(...)` as a bare tensor (`hidden_states = residual + hidden_states`). The wrapper returned the v4 `(final_hidden_states, router_logits)` tuple — the same one-frame-later `TypeError: Tensor + tuple` failure danielesalpietro observed on OLMoE after fixing its registration constant. Static verification against transformers `main` (5.x) confirms the decoder-layer contract; a hardware run is still required for a serve claim.

**Return-contract test added:** `tests/python/unit/test_jamba_return_contract.py` stubs `expert_executor` (isolating the wrapper's own contract from the distributed layer) and asserts `forward` returns a bare tensor of input shape that survives `residual + out`. Negative control run locally: reverting the return to the tuple fails the test (`AssertionError ... got <class 'tuple'>`); it passes after the fix. Registration-layout tests cannot see this class of defect — this is the test boundary flagged in review.

**Verification (CPU, darwin arm64, CPython 3.14.7, transformers 5.16.1, torch 2.14.0 CPU):**
- Layout test: fails on `main` (`02a4afe`); passes with the fix.
- Return-contract test: passes with fix; negative control fails as expected; tree restored and diff verified clean before commit.
- Changed-file ruff check/format and the repo-configured mypy scope pass.
- Broad `tests/python/unit tests/python/serving` CPU run: 897 passed / 22 failed / 23 errors / 26 skipped — **the failing/error node set is byte-identical on unmodified `main`** under this environment (mostly FastAPI TestClient/serving tests), i.e. pre-existing, not introduced here.

**Scope:** CPU registration-layout and return-contract tests only. No OLMoE/DBRX changes (DBRX fused weights need separate handling), no native CUDA numerical-correctness claim, no serve claim.

---

**Scope caveat — updated 2026-09-11 after @danielesalpietro's corrigendum ([#206 comment](https://github.com/EfficientMoE/MoE-Infinity/pull/206#issuecomment-5625472192)):** this PR fixes Jamba's expert mapping and its wrapper return contract — the expert path. It does **not** make Jamba serve correctly under multi-token decode.

The earlier wording here said multi-token decode "is expected to remain incorrect until a shim exists," implying a `JambaPagedAttention` shim would be sufficient. That is now known to be wrong, and I am correcting it rather than editing it away:

- A shim is **necessary but not sufficient**. @danielesalpietro withdrew the earlier "Qwen3 decodes correctly" datapoint (it rested on a tiny random Qwen3-MoE whose output merely varied); a real Qwen3-30B-A3B run collapses identically, and he reran OLMoE multi-token himself after both #207 fixes — still collapsing.
- The second, shim-independent defect is in `PagedAttentionBackend`: the fallback `_k_cache`/`_v_cache` carry **no layer dimension**, so `write_kv`'s `layer_idx` argument is accepted and silently ignored and every decoder layer writes the same buffer. Diagnosed with CPU runtime evidence in [#195](https://github.com/EfficientMoE/MoE-Infinity/pull/195#issuecomment-5627929822) (`LAYER_DIM_PRESENT: False`, `SILENT_ALIASING: True`, on a clean `main` worktree `02a4afe`).
- **Practical consequence:** a `JambaPagedAttention` shim written and tested against current `main` today will appear not to work, with no way to attribute the failure to the shim or to the backend. Jamba needs **both** the shim and the #195 backend fix. Anyone picking up the shim should land or stack on #195 first.

The expert-path fixes in this PR are unaffected by the above and stand on their own CPU evidence; @danielesalpietro confirmed both. 'Jamba expert path fixed' should still not be read as 'Jamba serves'.