### PR TITLE
docs: sync env-var and architecture docs with code

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,7 +62,6 @@ moe_infinity/
 ├── engine/              Deprecated synchronous generation path (powers MoE.generate)
 │   ├── generation_loop.py     GenerationEngine, spec_strategy seam, standard fallback
 │   ├── scheduler.py           Request scheduler with block-level KV allocation
-│   ├── request_manager.py     Thread-safe request lifecycle
 │   ├── types.py               Request, Sequence, SamplingParams, status enums
 │   ├── transfer_types.py      TransferRequest, TransferPriority, TransferType
 │   ├── unified_transfer_scheduler.py  Coordinates expert + KV transfers
@@ -88,8 +87,6 @@ moe_infinity/
 │   ├── validation.py          Request validation + error shaping
 │   ├── health.py              /health endpoint state
 │   ├── watchdog.py            Startup / decode timeout enforcement
-│   ├── expert_batch.py        BatchedExpertDispatch helper
-│   ├── expert_prefetch_coordinator.py   Cross-request prefetch hints
 │   ├── eviction_sync.py       Request-termination → ContextPilot eviction
 │   └── contextpilot_*.py      Optional prompt-optimization middleware
 │
@@ -114,7 +111,6 @@ moe_infinity/
 │   ├── offloading_policy.py   LRU / ARC cache policies
 │   ├── kv_cache_manager.py    Python-side KV block bookkeeping
 │   ├── block_pool.py          Block allocator abstraction
-│   ├── cpu_block_cache.py     CPU-resident KV block staging area
 │   └── memory_coordinator.py  Shared GPU memory budget between experts + KV
 │
 ├── distributed/         Multi-GPU expert dispatch

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -35,11 +35,18 @@ With `gpu_only_expert_routing=true`, full sampling emits `gpu_route_submit`,
 `route_failures` count or any unexpected `gpu_route_fallback` event is a
 rollback signal; set `gpu_only_expert_routing=false` and retain the eager path.
 
-## Deterministic mode
+## C++ runtime configuration
+
+These keys are read by the compiled C++/CUDA offload engine (the `_store`
+extension built from `core/`, see `setup.py`). They tune the native
+prefetch/AIO and caching-allocator paths and are parsed with C `getenv`.
 
 | Variable | Default | Where read | Effect | Notes |
 | --- | --- | --- | --- | --- |
-| `MOE_DETERMINISTIC` | unset, treated as off | `moe_infinity/kernel/deterministic_matmul.py` import time | If `"1"`, turn on deterministic algorithms, set `CUBLAS_WORKSPACE_CONFIG=:16:8`, and set `NCCL_ALGO=Tree`. | The module snapshots and restores the previous values on disable. `CUBLAS_WORKSPACE_CONFIG` and `NCCL_ALGO` are standard CUDA/NCCL knobs, not MoE-Infinity env vars. |
+| `MOE_IO_THREADS` | unset, treated as `0` (auto) | `core/prefetch/archer_prefetch_handle.cpp` handle construction | Number of background I/O threads the native prefetch/AIO engine uses to read expert weights. | Parsed with `atoi`; `0` or unset defers to the AIO layer's hardware-derived `ArcherPrioAioContext::GetDefaultNumIoThreads()`. |
+| `MOE_IO_BLOCK_SIZE_KB` | `1024` (1 MiB) | `core/aio/archer_prio_aio_handle.cpp` static init | Read/transfer block size for the priority AIO path (in KB), which also sizes the pinned-memory pool blocks. | Only applied when the value is in `[256, 65536]` KB; any other value falls back to the 1 MiB default. |
+| `MOEINF_GPU_SIZE` | unset, full device memory | `core/memory/caching_allocator.h` allocator init (CUDA path) | Overrides the GPU caching-allocator capacity, in bytes. | Read via `std::stoull`. If unset, the allocator uses the device's total global memory (`cudaGetDeviceProperties`). |
+| `MOEINF_PIN_SIZE` | required (no default) | `core/memory/caching_allocator.h` allocator init (pinned path) | Sets the pinned-host caching-allocator capacity, in bytes. | Read via `std::stoull`. Unset trips a fatal log when the pinned allocator initializes, so set it when the pinned path is used. |
 
 ## Model-specific toggles
 
@@ -95,9 +102,11 @@ Repo evidence:
 - `moe_infinity/serving/cuda_graph.py`
 - `moe_infinity/profiling/io_profiler.py`
 - `moe_infinity/memory/expert_tracer.py`
-- `moe_infinity/kernel/deterministic_matmul.py`
 - `moe_infinity/runtime/model_offload.py`
 - `moe_infinity/models/deepseek_v4/official_offload_adapter.py`
 - `moe_infinity/entrypoints/openai/api_server_v2.py`
+- `core/prefetch/archer_prefetch_handle.cpp`
+- `core/aio/archer_prio_aio_handle.cpp`
+- `core/memory/caching_allocator.h`
 - `setup.py`
 - `CMakeLists.txt`


### PR DESCRIPTION
## Summary

Syncs the global-flag / environment-variable documentation and the architecture
module map with the actual source tree. Docs-only; no source code changes. Every
claim below was verified directly against the code in this branch.

## `docs/environment-variables.md`

### Added — new "C++ runtime configuration" section

Env vars read by the compiled `_store` extension (built from `core/`, per
`setup.py`). Each was verified: the `getenv` read exists **and** the file is
compiled/included:

| Variable | Default | Source | Notes |
| --- | --- | --- | --- |
| `MOE_IO_THREADS` | unset → `0` (auto) | `core/prefetch/archer_prefetch_handle.cpp` (in `_STORE_SOURCES`) | `atoi`; `0`/unset → `GetDefaultNumIoThreads()` |
| `MOE_IO_BLOCK_SIZE_KB` | `1024` KB (1 MiB) | `core/aio/archer_prio_aio_handle.cpp` (in `_STORE_SOURCES`) | applied only in `[256, 65536]` KB |
| `MOEINF_GPU_SIZE` | unset → full device memory | `core/memory/caching_allocator.h` (included by compiled `caching_allocator.cpp`, CUDA path) | `std::stoull`, bytes |
| `MOEINF_PIN_SIZE` | required (fatal if unset) | `core/memory/caching_allocator.h` (pinned path, reached via `TorchAllocate`) | `std::stoull`, bytes |

### Removed — stale entry

- **`MOE_DETERMINISTIC`**: pointed at `moe_infinity/kernel/deterministic_matmul.py`,
  which no longer exists; grep confirms zero code references remain (only the doc
  referenced it). Removed the entry and its `Repo evidence` bullet.

### Repo evidence list

- Dropped `moe_infinity/kernel/deterministic_matmul.py`.
- Added `core/prefetch/archer_prefetch_handle.cpp`,
  `core/aio/archer_prio_aio_handle.cpp`, `core/memory/caching_allocator.h`.

### Intentionally NOT documented (verified not live)

- **`SPDLOG_LEVEL`**: only read in `core/utils/archer_logger.cpp`, which is not in
  any `setup.py` source list and is not `#include`d by a compiled source. The read
  in the compiled `core/utils/logger.cpp` is commented out.
- **`MOEINF_SHM_SIZE`**: its `getenv` sits in the `MemoryType::SHM` branch of
  `caching_allocator.h`, but `InitCachingAllocator` is only ever called with
  `PIN`/`CUDA` (`caching_allocator.cpp`), so the SHM branch is unreachable in the
  built extension.

## `ARCHITECTURE.md`

Removed module-map entries for files deleted from the tree (each confirmed
missing in this branch):

- `engine/request_manager.py`
- `serving/expert_batch.py`
- `serving/expert_prefetch_coordinator.py`
- `memory/cpu_block_cache.py`

All other referenced modules in the map were checked and still exist; the ASCII
tree remains valid.

## Verification

- `getenv`/reference checks via `git grep` and file-existence checks in this
  worktree.
- `pre-commit run --files ARCHITECTURE.md docs/environment-variables.md` → all
  applicable hooks pass (trailing-whitespace, EOF, codespell, etc.).