### PR TITLE
feat(deepseek): DeepSeek-V4.1-Flash support (registry + parsing + plan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to MoE-Infinity will be documented in this file.
 - No-download unified-execution benchmark/validator and compatibility assertions that fail closed on sampling, ordering, cache invariant, or ownership failures.
 - Documented GLM-5.3 (`zai-org/GLM-5.3`) as running through the existing GlmMoeDsa path (same base as GLM-5.2), with a config-resolution regression test (`tests/python/unit/test_glm53_registry.py`).
 - GLM-5.3-Flash (`zai-org/GLM-5.3-Flash`) glm5_next family support: guarded registry entry, nested text_config parsing, `SyncGlm5NextMoEBlock`, and offload runtime wiring (routed FP8 experts offloaded; KDA/DSA/mHC/vision resident, text-only).
+- DeepSeek-V4.1-Flash (`deepseek-ai/DeepSeek-V4.1-Flash`, `DeepseekV41ForCausalLM`) **Phase 1 (in progress / draft)**: guarded registry entry and nested `text_config` config parsing only (384 routed FP4 experts, top-6, `sqrtsoftplus`/`noaux_tc`), with substring-dispatch precedence over the V4 entry and a phased implementation plan (`docs/deepseek-v41-flash-plan.md`). Expert offload and the CED/Engram/CSA2/DSpark/vision architecture are not yet implemented.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ MoE-Infinity supports HuggingFace MoE checkpoints registered in [`moe_infinity/c
 |---|---|
 | [DeepSeek-V2 / V3](https://huggingface.co/collections/deepseek-ai/deepseek-v2-669a1c8b8f2dbc203fbd7746) | `deepseek-ai/DeepSeek-V2-Lite-Chat`, `deepseek-ai/DeepSeek-V3` |
 | DeepSeek-V4-Flash (FP4 expert offloading) | `deepseek-ai/DeepSeek-V4-Flash` |
+| [DeepSeek-V4.1-Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash) *(in progress / draft)* | `deepseek-ai/DeepSeek-V4.1-Flash` |
 | [Mixtral](https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1) | `mistralai/Mixtral-8x7B-Instruct-v0.1`, `Mixtral-8x22B` |
 | [Qwen3-MoE](https://huggingface.co/Qwen/Qwen3-30B-A3B) | `Qwen/Qwen3-30B-A3B` |
 | [Qwen3.5-MoE](https://huggingface.co/Qwen/Qwen3.5-35B-A3B) | `Qwen/Qwen3.5-35B-A3B` |
@@ -68,6 +69,8 @@ MoE-Infinity supports HuggingFace MoE checkpoints registered in [`moe_infinity/c
 | [Meta NLLB-MoE](https://huggingface.co/facebook/nllb-moe-54b) | `facebook/nllb-moe-54b` |
 
 > DeepSeek-V4-Flash is only registered when your installed `transformers` provides `DeepseekV4ForCausalLM`; otherwise it is skipped automatically. Path A uses the HF-native `MoE` wrapper, and Path B uses the official FP4 offload loader. See [docs/model-compatibility.md](docs/model-compatibility.md) and [moe_infinity/models/deepseek_v4/README.md](./moe_infinity/models/deepseek_v4/README.md).
+
+> DeepSeek-V4.1-Flash (`DeepseekV41ForCausalLM`, `model_type="deepseek_v41"`) is **in progress / draft**. Phase 1 ships only the guarded registry entry and nested-`text_config` config parsing (384 routed FP4 experts, top-6, `sqrtsoftplus`/`noaux_tc`); it is registered only when your `transformers` provides `DeepseekV41ForCausalLM` (mainline has not merged `deepseek_v41` as of 2026-09-12, so this usually requires the `trust_remote_code` path). Expert offload (Phase 2) and the CED/Engram/CSA2/DSpark/vision architecture (Phase 3) are not yet implemented. See [docs/deepseek-v41-flash-plan.md](docs/deepseek-v41-flash-plan.md).
 
 > Qwen3.5-MoE (`Qwen3_5MoeForConditionalGeneration`, requires `transformers` >= 5.12) is a vision-language checkpoint served text-only. Its 256 routed experts are offloaded while the text backbone, token embeddings, hybrid linear and full attention layers, shared expert, and `lm_head` stay resident on GPU. The v5 packed expert tensors expand to per-expert on load. Vision and MTP weights are present but unused for text generation. See [docs/model-compatibility.md](docs/model-compatibility.md).
 

--- a/docs/deepseek-v41-flash-plan.md
+++ b/docs/deepseek-v41-flash-plan.md
@@ -1,0 +1,165 @@
+# DeepSeek-V4.1-Flash support — phased implementation plan
+
+Status: **draft / in progress**. This document tracks the incremental plan for
+adding `deepseek-ai/DeepSeek-V4.1-Flash` (arch `DeepseekV41ForCausalLM`,
+`model_type="deepseek_v41"`) to MoE-Infinity. Only **Phase 1** (registry +
+config parsing + tests + docs) ships in the first PR; later phases are scoped
+here but not yet implemented.
+
+## Model facts
+
+Source: <https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash> (config).
+
+| Field | Value |
+| --- | --- |
+| `model_type` | `deepseek_v41` |
+| `architectures` | `["DeepseekV41ForCausalLM"]` |
+| `hidden_size` | 5120 |
+| `vocab_size` | 129280 |
+| `max_position_embeddings` | 1048576 (1M) |
+| `torch_dtype` | bfloat16 |
+| Quantization | fp8 dynamic (non-expert) + `expert_dtype="fp4"` (routed experts) |
+| `weight_block_size` | `[32, 32]` |
+| `num_hidden_layers` | 40 (CED: 20 encoder + 20 decoder) |
+| `n_routed_experts` | 384 |
+| `num_experts_per_tok` | 6 (top-6) |
+| `moe_intermediate_size` | 2304 |
+| `n_shared_experts` | 1 |
+| `scoring_func` | `sqrtsoftplus` |
+| `topk_method` | `noaux_tc` |
+| `routed_scaling_factor` | 1.5 |
+| Config nesting | MoE fields under `text_config` (VL wrapper, native vision tower `deepseek_v41_vision`) |
+
+Architecture-defining extras (relevant to later phases):
+
+- **CED** conditional encoder-decoder: 40 layers = 20 encoder + 20 decoder.
+- **Engram** conditional memory: ~196B params, `engram_layer_ids=[1, 14]`,
+  `engram_vocab_size=16000000` (16M).
+- **CSA2** sparse attention: `sliding_window=128`,
+  `kv_source_layer_ids=[2, 8, 14, 20]`, `index_topk=512`.
+- **DSpark** multi-token prediction: `num_nextn_predict_layers=3`,
+  `dspark_n_routed_experts=128`.
+- **FP4 KV cache**: ~890 B/token.
+
+## Transformers availability
+
+- `transformers >= 5.6` *declares* the model, but **mainline transformers has
+  NOT merged `deepseek_v41` as of 2026-09-12**. On a typical install
+  `DeepseekV41ForCausalLM` is not importable, so the registry entry is skipped
+  and loading a real checkpoint would go through the `trust_remote_code=True`
+  path.
+- All Phase-1 code is guarded exactly like the existing `DeepseekV4ForCausalLM`
+  guard (class may be `None`; the registry never maps to a `None` class).
+
+## Prior art
+
+vLLM's implementation is the reference for later phases (vllm
+`vllm/model_executor/models/deepseek_v4_1/` at commit `8065045`):
+
+- `attention.py` — MLA + CSA2 sparse attention.
+- `sparse_mla.py` — sparse MLA kernels.
+- `compressor.py` — CED / conditional-memory compression path.
+- `nvidia/vl_model.py` — native vision tower wiring.
+
+## Phase 1 — registry + config parsing + tests + docs (this PR)
+
+Touched files (registry/parsing/tests/docs only; **no** model wrapper or
+monkey-patch, deferred to Phase 2):
+
+- `moe_infinity/common/constants.py` — guarded import of
+  `DeepseekV41ForCausalLM`; conditional `MODEL_MAPPING_NAMES["deepseekv41"]` and
+  `MODEL_MAPPING_TYPES["deepseekv41"] = 5` (per-expert gate/up/down family, like
+  V4/Qwen3/GLM).
+- `moe_infinity/utils/hf_config.py` — `parse_moe_param` and `parse_expert_id`
+  `deepseekv41` branches, ordered **before** `deepseekv4`/`deepseek`.
+- `tests/python/unit/test_deepseekv41_registry.py` +
+  `tests/fixtures/deepseek_v41_flash/config.json` — CPU-only unit tests.
+- Docs: `docs/model-compatibility.md`, `README.md`, `CHANGELOG.md`, this file.
+
+### Substring-dispatch precedence (critical)
+
+The registry key `"deepseekv41"` contains `"deepseekv4"`, which itself contains
+`"deepseek"`. Two dispatch sites must resolve the most specific key first:
+
+1. `parse_expert_type` (constants.py) iterates keys sorted by length
+   descending, so `deepseekv41` (11) is matched before `deepseekv4` (10). Both
+   map to expert-type 5.
+2. `parse_moe_param` / `parse_expert_id` (hf_config.py) use ordered `if/elif`
+   substring checks. The `deepseekv41` branch is placed **before** the
+   `deepseekv4` and generic `deepseek` branches. If that order regressed, a
+   V4.1 config would fall through to the flat `deepseek` branch and read
+   top-level `num_hidden_layers` / `n_routed_experts`, which V4.1 nests under
+   `text_config` — raising `AttributeError`. A unit test pins this.
+
+Caveat (documented and tested): when a build ships `DeepseekV4ForCausalLM` but
+not `DeepseekV41ForCausalLM`, `parse_expert_type` on a V4.1 arch resolves to the
+registered `deepseekv4` key (also type 5) rather than raising, because
+`deepseekv4` is still a substring. Config parsing (`parse_moe_param` /
+`parse_expert_id`) is registry-independent and still routes V4.1 via its own
+arch-string branch — which is the Phase-1 correctness guarantee.
+
+### Open question carried into Phase 2
+
+- **Checkpoint key layout is UNCONFIRMED.** `parse_expert_id` currently reuses
+  the V4 `layers\.(\d+)\.ffn\.experts\.(\d+)\.` pattern (unanchored, so it also
+  matches a VL-style `language_model.layers.<L>.ffn.experts.<E>.` prefix). The
+  exact V4.1 routed-expert tensor names — including any MTP/DSpark layer suffix,
+  vision prefix, and FP4 packed/scale tensor naming — must be verified against
+  real safetensors shards before Phase 2 offload work.
+
+## Phase 2 — expert offload path (FP4)
+
+Reuse the existing `moe_infinity/models/deepseek_v4/` FP4 infrastructure; the
+quant format matches V4 (E2M1 + `ue8m0` block scale), so most of the host-store
++ streaming stack is reusable:
+
+- Routed experts are FP4; 384 experts, top-6, `moe_intermediate_size=2304`.
+- `weight_block_size=[32, 32]` (confirm the scale-block interpretation matches
+  the V4 `FP4_SCALE_BLOCK` path; V4 uses block-32 `ue8m0` scales).
+- Router: `scoring_func="sqrtsoftplus"`, `topk_method="noaux_tc"`,
+  `routed_scaling_factor=1.5` — reuse `deepseek_v4/routing.py` (`sqrtsoftplus`,
+  `topk_route`) where compatible.
+- `n_shared_experts=1` stays resident (FP8), like V4.
+- Deliverables mirror PR #201's family shape: a `SyncDeepSeekV41MoEBlock`
+  wrapper (or reuse `SyncDeepSeekV4MoEBlock`), `models/__init__.py` export, and
+  `runtime/model_offload.py` wiring — added only after the checkpoint key layout
+  is confirmed.
+
+Prerequisite: resolve the Phase-1 open question (real shard key layout) and add
+a real-checkpoint (or tiny-fixture) loader test.
+
+## Phase 3 — architecture gaps (NEW work, explicit unknowns)
+
+Each item needs new design work and is flagged as research where the mapping to
+existing MoE-Infinity infrastructure is not yet established:
+
+- **CED encoder-decoder split** — 40 layers = 20 encoder + 20 decoder. Phase 1
+  treats all 40 as decoder layers (`num_encoder_layers=0`). A real split needs
+  `parse_moe_param` to emit encoder/decoder counts and the offload topology to
+  respect the CED boundary. **Unknown:** whether routed experts differ between
+  encoder and decoder stacks.
+- **Engram conditional memory** — 196B, `engram_layer_ids=[1, 14]`,
+  `engram_vocab_size=16M`. Very large; a **candidate for host/SSD offload**
+  (not GPU-resident). **Research:** access pattern, whether it is sparse per
+  token, and whether it fits the existing expert host-store abstraction or needs
+  a new memory tier.
+- **CSA2 sparse attention** — `sliding_window=128`,
+  `kv_source_layer_ids=[2, 8, 14, 20]`, `index_topk=512`. Reference vLLM
+  `attention.py` / `sparse_mla.py`. Runs resident; needs an
+  `attn_implementation` selection compatible with the offload runtime.
+- **DSpark 3-layer MTP** — `num_nextn_predict_layers=3`,
+  `dspark_n_routed_experts=128`. Relate to the existing DFlash spec-decode path;
+  MTP layers must be excluded from routed-expert offload (add an MTP layer-id
+  guard in `parse_expert_id`, as GLM does).
+- **FP4 KV cache** — ~890 B/token. Interaction with the existing paged KV cache
+  and `kv_cache_format` options is undetermined.
+- **Native vision tower** (`deepseek_v41_vision`) — served **text-only first**,
+  exactly like Qwen3.5 and GLM-5.3-Flash; vision weights stay resident/unused
+  for text generation.
+
+## Non-goals for the first PR
+
+- No download of the 552B model.
+- No CED / Engram / CSA2 / DSpark / vision implementation.
+- No changes to the existing `moe_infinity/models/deepseek_v4/` V4 code paths
+  (V4.1 must not regress V4).

--- a/docs/model-compatibility.md
+++ b/docs/model-compatibility.md
@@ -24,6 +24,7 @@ a claim that any particular DeepSeek DFlash pair has been validated.
 | DeepSeek-V2 (`DeepseekV2ForCausalLM`) | validated | implemented/experimental | Eager consistency harness; Stage 4b details below. |
 | DeepSeek-V3 (`DeepseekV3ForCausalLM`) | implemented/experimental | implemented/experimental | Routing and paged-attention parity evidence. |
 | DeepSeek-V4 (`DeepseekV4ForCausalLM`) | validated official mp4 path | not validated | DFlash unsupported; mp1 not covered. |
+| DeepSeek-V4.1-Flash (`DeepseekV41ForCausalLM`) | in progress / draft | not recorded | Phase 1 only: guarded registry entry + nested `text_config` parsing (384 routed FP4 experts, top-6, `sqrtsoftplus`/`noaux_tc`). Expert offload + CED/Engram/CSA2/DSpark/vision deferred; see [docs/deepseek-v41-flash-plan.md](./deepseek-v41-flash-plan.md). |
 | Mixtral (`MixtralForCausalLM`) | implemented/experimental | implemented/experimental | No real-model serving harness recorded. |
 | Qwen3 / Qwen3.5 MoE | Qwen3 validated; Qwen3.5 tiny-fixture validated | implemented/experimental | Qwen3.5 is text-only and requires newer Transformers. |
 | GLM-5.2 (`GlmMoeDsaForCausalLM`) | validated | tiny serving harness | Built-in MTP, not DFlash. |

--- a/moe_infinity/common/constants.py
+++ b/moe_infinity/common/constants.py
@@ -18,6 +18,11 @@ except ImportError:
     DeepseekV4ForCausalLM = None
 
 try:
+    from transformers import DeepseekV41ForCausalLM
+except ImportError:
+    DeepseekV41ForCausalLM = None
+
+try:
     from transformers import Qwen3_5MoeForConditionalGeneration
 except ImportError:
     Qwen3_5MoeForConditionalGeneration = None
@@ -65,6 +70,18 @@ MODEL_MAPPING_TYPES = {
 if DeepseekV4ForCausalLM is not None:
     MODEL_MAPPING_NAMES["deepseekv4"] = DeepseekV4ForCausalLM
     MODEL_MAPPING_TYPES["deepseekv4"] = 5
+
+# DeepSeek-V4.1-Flash (arch "DeepseekV41ForCausalLM", model_type
+# "deepseek_v41") nests its MoE fields under text_config and routes 384
+# per-expert FP4 (E2M1 + ue8m0 scale) experts top-6 with the sqrtsoftplus /
+# noaux_tc router family (expert-type 5, like V4). Its key "deepseekv41"
+# contains "deepseekv4" as a substring; parse_expert_type matches the longest
+# registered key first (length-sort), so V4.1 resolves before V4. Mainline
+# transformers has not merged deepseek_v41 as of 2026-09-12, so the class is
+# usually absent; register only when it is importable (mirrors the V4 guard).
+if DeepseekV41ForCausalLM is not None:
+    MODEL_MAPPING_NAMES["deepseekv41"] = DeepseekV41ForCausalLM
+    MODEL_MAPPING_TYPES["deepseekv41"] = 5
 
 # Qwen3.5-MoE (arch "Qwen3_5MoeForConditionalGeneration") uses per-expert
 # gate_proj/up_proj/down_proj weights (expert-type 5, like Qwen3/DeepSeek); the

--- a/moe_infinity/utils/hf_config.py
+++ b/moe_infinity/utils/hf_config.py
@@ -125,6 +125,17 @@ def parse_moe_param(config: PretrainedConfig) -> Tuple[int, int, int]:
         num_decoder_layers = text.num_hidden_layers
         num_layers = text.num_hidden_layers
         num_experts = text.n_routed_experts
+    elif "deepseekv41" in arch:
+        # DeepSeek-V4.1-Flash is a VL wrapper: MoE fields nest under
+        # text_config (num_hidden_layers=40, n_routed_experts=384). Must precede
+        # the "deepseekv4" and generic "deepseek" branches, whose keys are
+        # substrings of "deepseekv41forcausallm". Phase 1 does not model the CED
+        # encoder/decoder split, so all layers count as decoder layers.
+        text = moe_text_config(config)
+        num_encoder_layers = 0
+        num_decoder_layers = text.num_hidden_layers
+        num_layers = text.num_hidden_layers
+        num_experts = text.n_routed_experts
     elif "deepseek" in arch:
         num_encoder_layers = 0
         num_decoder_layers = config.num_hidden_layers
@@ -175,6 +186,21 @@ def parse_expert_id(
         result = re.findall(
             r"layers\.(\d+)\.block_sparse_moe\.experts\.(\d+)\.", param_name
         )
+        if result:
+            layer_id, expert_id = result[0]
+            layer_id = int(layer_id)
+            expert_id = int(expert_id)
+    elif "deepseekv41" in arch:
+        decoder_sparse_step = 1
+        layer_type = "decoder"
+
+        # Reuses the V4 "ffn.experts" layout as a starting point; the exact
+        # V4.1 checkpoint key layout is UNCONFIRMED and must be verified against
+        # real shards (see docs/deepseek-v41-flash-plan.md, Phase 2). The
+        # pattern is unanchored so it also matches a VL-style
+        # "language_model.layers.<L>.ffn.experts.<E>." prefix. Must precede the
+        # "deepseekv4" branch, whose key is a substring of this arch.
+        result = re.findall(r"layers\.(\d+)\.ffn\.experts\.(\d+)\.", param_name)
         if result:
             layer_id, expert_id = result[0]
             layer_id = int(layer_id)

--- a/tests/fixtures/deepseek_v41_flash/config.json
+++ b/tests/fixtures/deepseek_v41_flash/config.json
@@ -1,0 +1,69 @@
+{
+  "architectures": [
+    "DeepseekV41ForCausalLM"
+  ],
+  "model_type": "deepseek_v41",
+  "dtype": "bfloat16",
+  "torch_dtype": "bfloat16",
+  "image_token_id": 128815,
+  "video_token_id": 128816,
+  "quantization_config": {
+    "quant_method": "fp8",
+    "fmt": "dynamic",
+    "expert_dtype": "fp4",
+    "weight_block_size": [
+      32,
+      32
+    ]
+  },
+  "text_config": {
+    "model_type": "deepseek_v41_text",
+    "hidden_size": 5120,
+    "vocab_size": 129280,
+    "max_position_embeddings": 1048576,
+    "num_hidden_layers": 40,
+    "num_attention_heads": 128,
+    "intermediate_size": 18432,
+    "n_routed_experts": 384,
+    "n_shared_experts": 1,
+    "num_experts_per_tok": 6,
+    "moe_intermediate_size": 2304,
+    "scoring_func": "sqrtsoftplus",
+    "topk_method": "noaux_tc",
+    "routed_scaling_factor": 1.5,
+    "n_group": 8,
+    "topk_group": 4,
+    "norm_topk_prob": true,
+    "first_k_dense_replace": 1,
+    "rms_norm_eps": 1e-06,
+    "q_lora_rank": 1536,
+    "kv_lora_rank": 512,
+    "qk_rope_head_dim": 64,
+    "qk_nope_head_dim": 128,
+    "v_head_dim": 128,
+    "num_nextn_predict_layers": 3,
+    "dspark_n_routed_experts": 128,
+    "engram_layer_ids": [
+      1,
+      14
+    ],
+    "engram_vocab_size": 16000000,
+    "sliding_window": 128,
+    "kv_source_layer_ids": [
+      2,
+      8,
+      14,
+      20
+    ],
+    "index_topk": 512,
+    "num_encoder_layers": 20,
+    "num_decoder_layers": 20
+  },
+  "vision_config": {
+    "model_type": "deepseek_v41_vision",
+    "hidden_size": 1152,
+    "num_hidden_layers": 27,
+    "num_attention_heads": 16
+  },
+  "transformers_version": "5.6.0"
+}

--- a/tests/python/unit/test_deepseekv41_registry.py
+++ b/tests/python/unit/test_deepseekv41_registry.py
@@ -1,0 +1,202 @@
+"""DeepSeek-V4.1-Flash (deepseek_v41) registry and config parsing.
+
+DeepSeek-V4.1-Flash (`deepseek-ai/DeepSeek-V4.1-Flash`, arch
+`DeepseekV41ForCausalLM`, `model_type="deepseek_v41"`) is a vision-language
+checkpoint whose MoE fields (`num_hidden_layers`, `n_routed_experts`, ...)
+nest under `text_config`, like the Qwen3.5 / GLM-5.3-Flash families. It ships
+384 routed FP4 (E2M1 + ue8m0 scale) experts per MoE layer, top-6 routing with
+`scoring_func="sqrtsoftplus"` / `topk_method="noaux_tc"`.
+
+Registration is guarded on the transformers class: mainline transformers has
+NOT merged `deepseek_v41` as of 2026-09-12, so `DeepseekV41ForCausalLM` is
+usually absent and the registry entry is skipped (mirrors the V4 / Qwen3.5 /
+GLM guards).
+
+SUBSTRING-DISPATCH TRAP: the registry key ``"deepseekv41"`` contains
+``"deepseekv4"`` as a substring. `parse_expert_type` matches the longest
+registered key first (constants.py length-sort), so a V4.1 config resolves to
+`deepseekv41` before `deepseekv4` when both are registered. The config-parsing
+branches in ``hf_config.py`` (``parse_moe_param`` / ``parse_expert_id``) are
+string-based and independent of the registry guard, and they place the
+``deepseekv41`` branch *before* both ``deepseekv4`` and the generic
+``deepseek`` branch so V4.1's nested-``text_config`` layout is used regardless
+of whether the HF class is importable.
+"""
+
+import json
+import os
+
+import pytest
+from transformers import PretrainedConfig
+
+from moe_infinity.common.constants import (
+    MODEL_MAPPING_NAMES,
+    MODEL_MAPPING_TYPES,
+    parse_expert_type,
+)
+from moe_infinity.utils.hf_config import parse_expert_id, parse_moe_param
+
+FIXTURE = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "fixtures",
+    "deepseek_v41_flash",
+    "config.json",
+)
+
+_HAS_V41 = "deepseekv41" in MODEL_MAPPING_NAMES
+_HAS_V4 = "deepseekv4" in MODEL_MAPPING_NAMES
+
+
+@pytest.fixture()
+def v41_flash_config() -> PretrainedConfig:
+    with open(FIXTURE) as f:
+        return PretrainedConfig.from_dict(json.load(f))
+
+
+@pytest.mark.skipif(
+    not _HAS_V41, reason="transformers lacks DeepseekV41ForCausalLM"
+)
+def test_registry_maps_deepseekv41_to_expert_type_5():
+    assert MODEL_MAPPING_TYPES["deepseekv41"] == 5
+
+
+@pytest.mark.skipif(
+    not _HAS_V41, reason="transformers lacks DeepseekV41ForCausalLM"
+)
+def test_registered_class_is_not_none():
+    cls = MODEL_MAPPING_NAMES["deepseekv41"]
+    assert cls is not None
+    assert hasattr(cls, "__name__")
+
+
+@pytest.mark.skipif(
+    not _HAS_V41, reason="transformers lacks DeepseekV41ForCausalLM"
+)
+def test_parse_expert_type_v41(v41_flash_config):
+    assert parse_expert_type(v41_flash_config) == 5
+
+
+def test_registry_substring_dispatch_v41_precedes_v4():
+    """The length-sorted match in ``parse_expert_type`` must pick the more
+    specific ``deepseekv41`` key first, so a V4.1 arch never resolves to the
+    ``deepseekv4`` entry when both are registered."""
+    arch = "deepseekv41forcausallm"
+    candidates = [
+        k
+        for k in sorted(MODEL_MAPPING_NAMES, key=len, reverse=True)
+        if k in arch
+    ]
+    if not _HAS_V41:
+        pytest.skip("transformers lacks DeepseekV41ForCausalLM")
+    assert candidates[0] == "deepseekv41"
+    if _HAS_V4:
+        assert candidates.index("deepseekv41") < candidates.index("deepseekv4")
+
+
+def test_length_sort_dispatch_selects_v41_over_v4(monkeypatch):
+    """Environment-independent proof of the length-sort precedence: register
+    both keys with distinct sentinel types and confirm a V4.1 arch resolves to
+    the more specific ``deepseekv41`` entry, never the ``deepseekv4`` substring
+    match."""
+    import moe_infinity.common.constants as constants
+
+    monkeypatch.setitem(constants.MODEL_MAPPING_NAMES, "deepseekv4", object)
+    monkeypatch.setitem(constants.MODEL_MAPPING_NAMES, "deepseekv41", object)
+    monkeypatch.setitem(constants.MODEL_MAPPING_TYPES, "deepseekv4", 5)
+    monkeypatch.setitem(constants.MODEL_MAPPING_TYPES, "deepseekv41", 99)
+
+    cfg = PretrainedConfig.from_dict(
+        {"architectures": ["DeepseekV41ForCausalLM"]}
+    )
+    assert constants.parse_expert_type(cfg) == 99
+
+
+@pytest.mark.skipif(
+    _HAS_V41,
+    reason="documents the fallback only when V4.1 is NOT registered",
+)
+def test_parse_expert_type_fallback_when_v41_unregistered(v41_flash_config):
+    """Substring-dispatch caveat: when the transformers build lacks
+    ``DeepseekV41ForCausalLM`` but ships ``DeepseekV4ForCausalLM``, the
+    ``deepseekv4`` key is still a substring of ``deepseekv41forcausallm`` and
+    is the most-specific *registered* key, so ``parse_expert_type`` resolves
+    to it (also expert-type 5) rather than raising. Config parsing still routes
+    V4.1 correctly via its own arch-string branches (tested below)."""
+    if _HAS_V4:
+        assert parse_expert_type(v41_flash_config) == 5
+    else:
+        with pytest.raises(RuntimeError, match="deepseekv41forcausallm"):
+            parse_expert_type(v41_flash_config)
+
+
+def test_parse_moe_param_reads_nested_text_config(v41_flash_config):
+    num_layers, num_experts, num_encoder_layers = parse_moe_param(
+        v41_flash_config
+    )
+    assert num_layers == 40
+    assert num_experts == 384
+    # Phase 1 does not model the CED encoder/decoder split; all 40 layers are
+    # treated as decoder layers.
+    assert num_encoder_layers == 0
+
+
+def test_parse_moe_param_prefers_v41_branch_over_flat_deepseek(
+    v41_flash_config,
+):
+    """Precedence guard at the config-parsing level: ``deepseekv41`` contains
+    both ``deepseekv4`` and ``deepseek``. The fixture defines
+    ``num_hidden_layers`` / ``n_routed_experts`` ONLY under ``text_config``, so
+    if the elif order regressed and a V4.1 config fell through to the flat
+    ``deepseek`` branch it would read the (absent) top-level fields and raise
+    ``AttributeError`` instead of returning the nested counts."""
+    assert not hasattr(v41_flash_config, "n_routed_experts")
+    num_layers, num_experts, _ = parse_moe_param(v41_flash_config)
+    assert (num_layers, num_experts) == (40, 384)
+
+
+@pytest.mark.parametrize(
+    "name,expected_layer,expected_expert",
+    [
+        # V4-native "ffn.experts" layout (see hf_config comment: exact V4.1
+        # checkpoint key layout must be confirmed against real shards).
+        ("model.layers.0.ffn.experts.0.w1.weight", 0, 0),
+        ("model.layers.5.ffn.experts.3.w2.weight", 5, 3),
+        ("model.layers.39.ffn.experts.383.w3.weight", 39, 383),
+        # Flexible/unanchored: also matches a VL-style language_model prefix.
+        (
+            "model.language_model.layers.14.ffn.experts.42.w1.weight_scale_inv",
+            14,
+            42,
+        ),
+    ],
+)
+def test_parse_expert_id_routed(
+    v41_flash_config, name, expected_layer, expected_expert
+):
+    layer_id, expert_id = parse_expert_id(name, v41_flash_config)
+    assert layer_id == expected_layer
+    assert expert_id == expected_expert
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # Shared expert (no numeric expert index) is resident, not routed.
+        "model.layers.3.ffn.shared_experts.gate_proj.weight",
+        "model.layers.3.ffn.gate.weight",
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.embed_tokens.weight",
+        "model.visual.blocks.0.attn.proj.weight",
+        "lm_head.weight",
+        # Generic ".mlp.experts." layout must NOT match the V4.1 ".ffn.experts."
+        # branch — this discriminates the v41 branch from the generic deepseek
+        # branch (which uses the mlp pattern).
+        "model.layers.3.mlp.experts.0.gate_proj.weight",
+    ],
+)
+def test_parse_expert_id_non_expert(v41_flash_config, name):
+    layer_id, expert_id = parse_expert_id(name, v41_flash_config)
+    assert layer_id is None
+    assert expert_id is None

--- a/tests/python/unit/test_model_registry.py
+++ b/tests/python/unit/test_model_registry.py
@@ -24,6 +24,8 @@ def test_all_models_registered():
     }
     if "deepseekv4" in MODEL_MAPPING_NAMES:
         expected_models.add("deepseekv4")
+    if "deepseekv41" in MODEL_MAPPING_NAMES:
+        expected_models.add("deepseekv41")
     if "qwen3_5" in MODEL_MAPPING_NAMES:
         expected_models.add("qwen3_5")
     if "glmmoedsa" in MODEL_MAPPING_NAMES:


### PR DESCRIPTION
## Summary

Adds **DeepSeek-V4.1-Flash** (`deepseek-ai/DeepSeek-V4.1-Flash`, arch `DeepseekV41ForCausalLM`, `model_type="deepseek_v41"`) to MoE-Infinity as the **first (Phase 1) slice**. This PR intentionally touches **only registry + config parsing + tests + docs**, mirroring the GLM-5.3-Flash worked example (#201) but deferring the model wrapper / offload runtime to Phase 2.

**Draft** because Phase 1 is registry/parsing only, the exact V4.1 checkpoint key layout is unconfirmed, and mainline `transformers` has not merged `deepseek_v41` yet.

## Phase 1 scope (this PR)

- **`moe_infinity/common/constants.py`** — guarded import of `DeepseekV41ForCausalLM` (class is `None` if `transformers` lacks it, exactly like the `DeepseekV4ForCausalLM` guard); conditional `MODEL_MAPPING_NAMES["deepseekv41"]` / `MODEL_MAPPING_TYPES["deepseekv41"] = 5` (per-expert gate/up/down family).
- **`moe_infinity/utils/hf_config.py`** — `parse_moe_param` (num_layers=40, num_experts=384, num_encoder_layers=0) and `parse_expert_id` (`deepseekv41`) branches, both ordered **before** `deepseekv4`/`deepseek`. Nested `text_config` handled via `moe_text_config()` like the Qwen3.5/GLM VL families. Reuses the V4 `layers\.(\d+)\.ffn\.experts\.(\d+)\.` key pattern with a code comment that the layout is unconfirmed.
- **Tests** — `tests/python/unit/test_deepseekv41_registry.py` + `tests/fixtures/deepseek_v41_flash/config.json` (synthetic config with real V4.1 numbers). CPU-only, no GPU marker, passes without the model downloaded. `tests/python/unit/test_model_registry.py` updated to accept the conditional `deepseekv41` key.
- **Docs** — `docs/deepseek-v41-flash-plan.md` (phased plan), plus "in progress / draft" rows in `README.md` and `docs/model-compatibility.md`, and a `CHANGELOG.md` entry.

### Substring-dispatch precedence (the tricky bit)

`"deepseekv41"` contains `"deepseekv4"` which contains `"deepseek"`. Both dispatch sites resolve the most specific key first:
- `parse_expert_type` length-sorts keys, so `deepseekv41` (11) beats `deepseekv4` (10).
- `parse_moe_param`/`parse_expert_id` place the `deepseekv41` `elif` **before** `deepseekv4`/`deepseek`; a regression would send a V4.1 config to the flat `deepseek` branch and raise `AttributeError` (V4.1 nests those fields under `text_config`). A unit test pins this, plus a monkeypatch test proving the length-sort precedence env-independently.

**Caveat (tested):** when a build ships `DeepseekV4ForCausalLM` but not `DeepseekV41ForCausalLM`, `parse_expert_type` on a V4.1 arch resolves to the registered `deepseekv4` key (also type 5) rather than raising. Config parsing is registry-independent and still routes V4.1 correctly.

## Phased plan (full detail in `docs/deepseek-v41-flash-plan.md`)

- **Phase 1 (this PR):** registry + parsing + tests + docs.
- **Phase 2:** expert offload reusing `moe_infinity/models/deepseek_v4/` FP4 infra (E2M1 + ue8m0 scale; `weight_block_size=[32,32]`; 384 experts top-6; `sqrtsoftplus`/`noaux_tc`; `routed_scaling_factor=1.5`; 1 shared expert; `moe_intermediate_size=2304`).
- **Phase 3 (new work, explicit unknowns):** CED encoder-decoder split (20+20), Engram conditional memory (196B, `engram_layer_ids=[1,14]`, 16M vocab — host/SSD offload candidate, flagged research), CSA2 sparse attention (`sliding_window=128`, `kv_source_layer_ids=[2,8,14,20]`, `index_topk=512`), DSpark 3-layer MTP (`num_nextn_predict_layers=3`, `dspark_n_routed_experts=128`), FP4 KV cache (~890 B/token), native vision tower (served text-only first, like Qwen3.5).

Prior art: vLLM `deepseek_v4_1/` at commit `8065045` (`attention.py`, `sparse_mla.py`, `compressor.py`, `nvidia/vl_model.py`). `transformers>=5.6` declares the model but mainline has NOT merged `deepseek_v41` as of 2026-09-12 (`trust_remote_code` path).

## Open questions

- [ ] **Checkpoint key layout** — the exact V4.1 routed-expert tensor names (MTP/DSpark suffixes, vision prefix, FP4 packed/scale naming) must be verified against real safetensors shards before Phase 2.
- [ ] **CED / Engram / CSA2 / DSpark / vision support strategy** — see Phase 3; each needs design work.

## Test evidence

```
$ PYTHONPATH=<worktree> python -m pytest tests/python/unit/test_deepseekv41_registry.py -q
14 passed, 4 skipped   # skips are the v41-class-guarded registry tests (transformers 5.12.1 lacks DeepseekV41ForCausalLM)
```
Neighboring registry/config tests (glm5_next, glm53, glm_registry, qwen3_5, qwen3, olmoe, model_registry, expert_precision) all pass — no substring-dispatch regression.

## Non-goals

No 552B download; no CED/Engram/CSA2/DSpark/vision; no changes to existing `moe_infinity/models/deepseek_v4/` V4 code paths.
