### PR TITLE
fix(contextpilot): wire eviction sync + CP-KV manager, bound adapter memory

### DIFF
--- a/moe_infinity/entrypoints/openai/api_server_v2.py
+++ b/moe_infinity/entrypoints/openai/api_server_v2.py
@@ -420,6 +420,49 @@ def _ensure_cp_middleware_initialized() -> Optional[Any]:
         return _cp_middleware
 
 
+def _wire_contextpilot_phase_c(runtime_engine: object) -> None:
+    """Install Phase C hooks (eviction sync + CP-aware KV manager).
+
+    When ContextPilot is inactive or absent, clears the eviction-sync
+    singleton and installs the Null KV manager. Failures are logged and
+    swallowed so wiring can never break server startup.
+    """
+    global _eviction_sync
+    try:
+        from moe_infinity.serving import engine as engine_module
+        from moe_infinity.serving.cp_kv_interface import (
+            ContextPilotKVManager,
+            NullCPAwareKVManager,
+        )
+
+        middleware = (
+            _ensure_cp_middleware_initialized()
+            if _is_contextpilot_active()
+            else None
+        )
+
+        if middleware is not None:
+            from moe_infinity.serving.eviction_sync import EvictionSyncAdapter
+
+            adapter = EvictionSyncAdapter(middleware)
+            engine_module.set_eviction_sync(adapter)
+            _eviction_sync = adapter
+            kv_manager: object = ContextPilotKVManager(middleware)
+            _cp_logger.info("ContextPilot Phase C wiring installed")
+        else:
+            engine_module.set_eviction_sync(None)
+            _eviction_sync = None
+            kv_manager = NullCPAwareKVManager()
+
+        for target_name in ("scheduler", "kv_cache"):
+            target = getattr(runtime_engine, target_name, None)
+            setter = getattr(target, "set_cp_kv_manager", None)
+            if callable(setter):
+                setter(kv_manager)
+    except Exception as exc:
+        _cp_logger.warning("ContextPilot Phase C wiring failed: %s", exc)
+
+
 def _process_chat_messages_with_contextpilot(
     messages: Any,
     *,
@@ -576,6 +619,7 @@ def initialize_with_model(
         stream_manager = StreamManager()
 
     engine = initialized_engine
+    _wire_contextpilot_phase_c(initialized_engine)
     _health_state.set_healthy()
 
 
@@ -1413,6 +1457,7 @@ async def _initialize_model() -> None:
             stream_manager = StreamManager()
 
         _replace_engine(initialized_engine)
+        _wire_contextpilot_phase_c(initialized_engine)
         configured_max_seq_length = engine_config.get("max_seq_length")
         if isinstance(configured_max_seq_length, int):
             runtime_max_seq_length = configured_max_seq_length

--- a/moe_infinity/serving/cp_kv_interface.py
+++ b/moe_infinity/serving/cp_kv_interface.py
@@ -33,6 +33,10 @@ class CPAwareKVManager(ABC):
     def get_allocation_priority(self, request_ids: list[str]) -> list[str]:
         """Returns request_ids sorted by CP overlap (highest first)"""
 
+    def remove_request(self, request_id: str) -> None:
+        """Drop all per-request tracking state on terminal removal"""
+        _ = request_id
+
 
 class NullCPAwareKVManager(CPAwareKVManager):
     @override
@@ -165,6 +169,10 @@ class ContextPilotKVManager(CPAwareKVManager):
             key=lambda rid: self.predict_prefix_reuse(rid, []),
             reverse=True,
         )
+
+    @override
+    def remove_request(self, request_id: str) -> None:
+        self._request_to_blocks.pop(request_id, None)
 
     def _get_middleware_callable(self, name: str) -> Optional[object]:
         return cast(Optional[object], getattr(self._middleware, name, None))

--- a/moe_infinity/serving/eviction_sync.py
+++ b/moe_infinity/serving/eviction_sync.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import threading
+from collections import OrderedDict
 from enum import Enum
 from typing import Optional, Protocol
+
+DEFAULT_MAX_TRACKED_REQUEST_IDS = 100_000
 
 
 class _CPMiddlewareLike(Protocol):
@@ -17,11 +20,19 @@ class EvictionEvent(Enum):
 
 
 class EvictionSyncAdapter:
-    def __init__(self, cp_middleware: Optional[_CPMiddlewareLike] = None):
+    def __init__(
+        self,
+        cp_middleware: Optional[_CPMiddlewareLike] = None,
+        *,
+        max_tracked_request_ids: int = DEFAULT_MAX_TRACKED_REQUEST_IDS,
+    ):
         """Takes optional CP middleware instance for remove_requests calls."""
+        if max_tracked_request_ids <= 0:
+            raise ValueError("max_tracked_request_ids must be > 0")
         self._cp_middleware: Optional[_CPMiddlewareLike] = cp_middleware
         self._lock: threading.RLock = threading.RLock()
-        self._evicted_request_ids: set[str] = set()
+        self._max_tracked_request_ids: int = int(max_tracked_request_ids)
+        self._evicted_request_ids: OrderedDict[str, None] = OrderedDict()
         self._evict_incoming: int = 0
         self._evict_removed: int = 0
         self._evict_not_found: int = 0
@@ -89,7 +100,11 @@ class EvictionSyncAdapter:
                 self._evict_not_found += 1
                 return
 
-            self._evicted_request_ids.add(request_id)
+            self._evicted_request_ids[request_id] = None
+            while (
+                len(self._evicted_request_ids) > self._max_tracked_request_ids
+            ):
+                self._evicted_request_ids.popitem(last=False)
 
             if callable(middleware_complete):
                 self._evict_removed += 1

--- a/moe_infinity/serving/kv_cache.py
+++ b/moe_infinity/serving/kv_cache.py
@@ -1111,10 +1111,14 @@ class PagedKVCache:
         if record is None and block_table is None:
             return
 
-        if self._cp_kv_manager is not None and block_table is not None:
+        if self._cp_kv_manager is not None:
             try:
-                block_hashes = block_table.get_block_ids()
-                self._cp_kv_manager.notify_blocks_freed(seq_id, block_hashes)
+                if block_table is not None:
+                    block_hashes = block_table.get_block_ids()
+                    self._cp_kv_manager.notify_blocks_freed(
+                        seq_id, block_hashes
+                    )
+                self._cp_kv_manager.remove_request(seq_id)
             except Exception:
                 pass
 

--- a/tests/python/contextpilot/test_phase_c_wiring.py
+++ b/tests/python/contextpilot/test_phase_c_wiring.py
@@ -1,0 +1,182 @@
+# pyright: reportAny=false, reportPrivateUsage=false
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_module(module_name: str, relative_path: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        module_name, ROOT / relative_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_EVICTION_SYNC_MODULE = _load_module(
+    "eviction_sync_phasec_test",
+    "moe_infinity/serving/eviction_sync.py",
+)
+_CP_KV_MODULE = _load_module(
+    "cp_kv_interface_phasec_test",
+    "moe_infinity/serving/cp_kv_interface.py",
+)
+EvictionSyncAdapter = _EVICTION_SYNC_MODULE.EvictionSyncAdapter
+ContextPilotKVManager = _CP_KV_MODULE.ContextPilotKVManager
+
+
+class _FakeMiddleware:
+    def on_request_complete(self, request_id: str) -> None:
+        _ = request_id
+
+
+class _RecordingCPTarget:
+    def __init__(self) -> None:
+        self.installed_manager: Any = "UNSET"
+
+    def set_cp_kv_manager(self, manager: Any) -> None:
+        self.installed_manager = manager
+
+
+class _FakeEngine:
+    def __init__(self) -> None:
+        self.scheduler = _RecordingCPTarget()
+        self.kv_cache = _RecordingCPTarget()
+
+
+class _RecordedCP:
+    def __init__(self) -> None:
+        self.removed: list[str] = []
+
+    def on_request_complete(self, request_id: str) -> None:
+        self.removed.append(request_id)
+
+
+@pytest.fixture
+def api_server_env(monkeypatch: pytest.MonkeyPatch):
+    import moe_infinity.serving.engine as engine_module
+
+    api_server = importlib.import_module(
+        "moe_infinity.entrypoints.openai.api_server_v2"
+    )
+
+    monkeypatch.delenv("CONTEXTPILOT_ENABLED", raising=False)
+    prev_enabled = api_server._contextpilot_enabled
+    prev_middleware = api_server._cp_middleware
+    prev_sync = api_server._eviction_sync
+    prev_engine_sync = engine_module._eviction_sync
+    try:
+        yield api_server, engine_module
+    finally:
+        api_server._contextpilot_enabled = prev_enabled
+        api_server._cp_middleware = prev_middleware
+        api_server._eviction_sync = prev_sync
+        engine_module.set_eviction_sync(prev_engine_sync)
+
+
+def test_cp_enabled_init_installs_eviction_sync(api_server_env) -> None:
+    api_server, engine_module = api_server_env
+    canonical_sync = importlib.import_module(
+        "moe_infinity.serving.eviction_sync"
+    )
+    canonical_cp_kv = importlib.import_module(
+        "moe_infinity.serving.cp_kv_interface"
+    )
+    api_server._contextpilot_enabled = True
+    api_server._cp_middleware = _FakeMiddleware()
+    engine_module.set_eviction_sync(None)
+
+    fake_engine = _FakeEngine()
+    api_server._wire_contextpilot_phase_c(fake_engine)
+
+    assert isinstance(
+        api_server._eviction_sync, canonical_sync.EvictionSyncAdapter
+    )
+    assert isinstance(
+        engine_module._eviction_sync, canonical_sync.EvictionSyncAdapter
+    )
+    assert isinstance(
+        fake_engine.scheduler.installed_manager,
+        canonical_cp_kv.ContextPilotKVManager,
+    )
+    assert isinstance(
+        fake_engine.kv_cache.installed_manager,
+        canonical_cp_kv.ContextPilotKVManager,
+    )
+
+
+def test_cp_disabled_init_installs_nothing(api_server_env) -> None:
+    api_server, engine_module = api_server_env
+    canonical_cp_kv = importlib.import_module(
+        "moe_infinity.serving.cp_kv_interface"
+    )
+    api_server._contextpilot_enabled = False
+    api_server._cp_middleware = None
+    engine_module.set_eviction_sync(None)
+
+    fake_engine = _FakeEngine()
+    api_server._wire_contextpilot_phase_c(fake_engine)
+
+    assert api_server._eviction_sync is None
+    assert engine_module._eviction_sync is None
+    assert isinstance(
+        fake_engine.scheduler.installed_manager,
+        canonical_cp_kv.NullCPAwareKVManager,
+    )
+    assert isinstance(
+        fake_engine.kv_cache.installed_manager,
+        canonical_cp_kv.NullCPAwareKVManager,
+    )
+
+
+def test_evicted_request_ids_is_bounded() -> None:
+    cap = 3
+    adapter = EvictionSyncAdapter(
+        _FakeMiddleware(), max_tracked_request_ids=cap
+    )
+
+    for i in range(50):
+        adapter.on_request_finished(f"req-{i}")
+
+    assert len(adapter._evicted_request_ids) <= cap
+
+
+def test_bounded_eviction_still_dedups_recent_ids() -> None:
+    cp = _RecordedCP()
+    adapter = EvictionSyncAdapter(cp, max_tracked_request_ids=8)
+
+    adapter.on_request_finished("req-A")
+    adapter.on_request_finished("req-A")
+
+    assert cp.removed == ["req-A"]
+
+
+def test_request_to_blocks_cleaned_on_removal() -> None:
+    manager = ContextPilotKVManager(_FakeMiddleware())
+
+    manager.notify_blocks_allocated("req-1", [1, 2, 3])
+    assert "req-1" in manager._request_to_blocks
+
+    manager.remove_request("req-1")
+
+    assert "req-1" not in manager._request_to_blocks
+
+
+def test_remove_request_is_idempotent() -> None:
+    manager = ContextPilotKVManager(_FakeMiddleware())
+
+    manager.notify_blocks_allocated("req-1", [1, 2, 3])
+    manager.remove_request("req-1")
+    manager.remove_request("req-1")
+
+    assert manager._request_to_blocks == {}


### PR DESCRIPTION
## Summary

Fixes the ContextPilot **Phase C wiring gaps** documented in #208. The adapters and interfaces existed but were never connected during server initialization, so terminal request events never reached the ContextPilot index and two per-request maps grew for the lifetime of the server.

Verified on `main` before this change: `set_eviction_sync()` and `set_cp_kv_manager()` had **zero call sites** in production code.

## Wired in this PR (serving path)

1. **Eviction sync installed** — `api_server_v2._wire_contextpilot_phase_c()` (called from both `initialize_with_model` and `_initialize_model`) constructs an `EvictionSyncAdapter(middleware)` and installs it via `moe_infinity.serving.engine.set_eviction_sync()` when ContextPilot is active. Terminal completion/abort in the engine now reach the CP index.
2. **CP-aware KV manager installed** — the same helper calls `set_cp_kv_manager()` on the serving `scheduler` **and** `kv_cache`: `ContextPilotKVManager` when CP is active, `NullCPAwareKVManager` otherwise. This activates the existing (previously dead) `predict_prefix_reuse` ordering and `notify_blocks_allocated`/`notify_blocks_freed` call sites in `serving/scheduler.py` + `serving/kv_cache.py`.
3. **Bounded memory:**
   - `EvictionSyncAdapter._evicted_request_ids` is now an `OrderedDict` LRU capped by `max_tracked_request_ids` (evicts oldest on overflow) instead of an unbounded `set`.
   - `ContextPilotKVManager` gains `remove_request()`, wired into `PagedKVCache.free_sequence` on terminal free so `_request_to_blocks` is reliably cleaned.

### Graceful degradation preserved
`_wire_contextpilot_phase_c()` is a no-op-safe seam: when ContextPilot is disabled or its package is absent it clears the eviction-sync singleton and installs `NullCPAwareKVManager` (identity ordering, zero-score), keeping the serving path byte-for-byte identical. Any wiring failure is logged and swallowed, so it can never break server startup.

## Deferred (not in this PR)

- **Native engine path** (`moe_infinity/engine/scheduler.py`) `set_cp_kv_manager()` wiring — this PR is scoped to the v2 serving path only.
- Secondary risks from the #208 audit (middleware lock held across `optimize()` with no timeout; non-terminal free *defer* semantics). These are behavior-sensitive and left untouched to keep the diff minimal.

Because the native path and the secondary risks remain, this PR uses **Refs #208** rather than auto-closing the issue.

## Tests

New CPU-only, mock-based tests in `tests/python/contextpilot/test_phase_c_wiring.py` (same style as `test_eviction_sync.py` / `test_middleware.py`), written test-first:

- `test_cp_enabled_init_installs_eviction_sync` — CP-enabled init installs the adapter + `ContextPilotKVManager`.
- `test_cp_disabled_init_installs_nothing` — disabled init clears eviction sync and installs `NullCPAwareKVManager`.
- `test_evicted_request_ids_is_bounded` / `test_bounded_eviction_still_dedups_recent_ids` — bounded dedup set.
- `test_request_to_blocks_cleaned_on_removal` / `test_remove_request_is_idempotent` — per-request block map cleanup.

```
$ python -m pytest tests/python/contextpilot/ -m "not gpu and not integration" -x -q
82 passed, 1 skipped, 4 warnings in 4.35s
```

All pre-existing ContextPilot tests continue to pass (76 → 82 with the 6 new tests). `pre-commit` (ruff, ruff-format, codespell, etc.) is clean on all changed files.

Refs #208
