### PR TITLE
style: ruff-format two pre-existing test files to fix CI

### DIFF
--- a/tests/python/unit/test_jamba_return_contract.py
+++ b/tests/python/unit/test_jamba_return_contract.py
@@ -15,7 +15,9 @@ torch = pytest.importorskip("torch")
 modeling = pytest.importorskip("transformers.models.jamba.modeling_jamba")
 
 if not hasattr(modeling, "JambaMLP"):
-    pytest.skip("transformers does not expose JambaMLP", allow_module_level=True)
+    pytest.skip(
+        "transformers does not expose JambaMLP", allow_module_level=True
+    )
 
 
 def test_forward_returns_bare_tensor():

--- a/tests/python/unit/test_olmoe_return_contract.py
+++ b/tests/python/unit/test_olmoe_return_contract.py
@@ -21,7 +21,9 @@ torch = pytest.importorskip("torch")
 modeling = pytest.importorskip("transformers.models.olmoe.modeling_olmoe")
 
 if not hasattr(modeling, "OlmoeMLP"):
-    pytest.skip("transformers does not expose OlmoeMLP", allow_module_level=True)
+    pytest.skip(
+        "transformers does not expose OlmoeMLP", allow_module_level=True
+    )
 
 
 def test_forward_returns_bare_tensor():


### PR DESCRIPTION
## Problem

The `lint` and `unit-tests` CI jobs run `pre-commit run --all-files`. That gate currently **fails on `main`** because two test files were merged without `ruff-format` (v0.6.9, the rev pinned in `.pre-commit-config.yaml`):

- `tests/python/unit/test_jamba_return_contract.py` (added in #206)
- `tests/python/unit/test_olmoe_return_contract.py` (added in #207)

Reproduced locally with the pinned ruff:
```
$ ruff format --check .
Would reformat: tests/python/unit/test_jamba_return_contract.py
Would reformat: tests/python/unit/test_olmoe_return_contract.py
2 files would be reformatted, 575 files left unchanged
```

Because the check runs over **all files**, every open PR inherits this failure regardless of what it changes (e.g. a docs-only PR fails the identical `ruff-format` hook).

## Fix

Apply `ruff format` to those two files. Formatting-only — **no logic change**. After this lands, `pre-commit run --all-files` passes on `main`, unblocking the `lint` / `unit-tests` gate for all open PRs (#209, #210, #211).

## Verification
```
$ ruff format --check .   # after fix
577 files already formatted
```
All other pre-commit hooks (ruff, codespell, clang-format, mypy) already pass.